### PR TITLE
Logging and minor SFTP/SSH transfer changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,20 @@
       "preLaunchTask": "Build Test containers",
       "program": "src/opentaskpy/cli/task_run.py",
       "console": "integratedTerminal",
-      "args": ["-t", "scp-basic", "-v", "3", "-c", "test/cfg"],
+      "args": ["-t", "scp-basic", "-c", "test/cfg"],
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Transfer - Basic - JSON Logging",
+      "type": "python",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": ["-t", "scp-basic", "-c", "test/cfg"],
+      "env": {
+        "OTF_LOG_JSON": "1"
+      },
       "justMyCode": false
     },
     {
@@ -90,7 +103,7 @@
       "preLaunchTask": "Build Test containers",
       "program": "src/opentaskpy/cli/task_run.py",
       "console": "integratedTerminal",
-      "args": ["-t", "batch-basic", "-v", "1", "-c", "test/cfg"],
+      "args": ["-t", "batch-basic", "-c", "test/cfg"],
       "justMyCode": false
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix SSH transfers to ensure that SSH connections are fully closed after use
 - Update SFTP transfers to use .partial file extension while files are being uploaded, and then rename them to their final name the transfer is complete.
 - Altered log level for some messages
+- Added `OTF_BATCH_RESUME_LOG_DATE` to allow resuming of batch runs from a specific date. This is useful if you want to rerun a batch from a specific date, especially if the failure happens just after midnight and the date is no longer the same as the original run.
 
 # v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# v0.12.0
+
+- Tidy up logging
+- Fix SSH transfers to ensure that SSH connections are fully closed after use
+- Update SFTP transfers to use .partial file extension while files are being uploaded, and then rename them to their final name the transfer is complete.
+
 # v0.11.0
 
 - Added ability to run local transfers and executions using new `local` protocol. This is based on the same syntax as the SSH based protocols but doesn't need a `hostname` to be defined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 # v0.12.0
 
+- Added JSON formatter for logging to stderr. This replaces the default Python logging format with structured JSON output. This is enabled by setting the `OTF_LOG_JSON` environment variable to `1`. Log files are not impact, as these are always in standard format, as this is required for the batch log parsing to allow for rerunability.
 - Tidy up logging
 - Fix SSH transfers to ensure that SSH connections are fully closed after use
 - Update SFTP transfers to use .partial file extension while files are being uploaded, and then rename them to their final name the transfer is complete.
+- Altered log level for some messages
 
 # v0.11.0
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ These are some environment variables that can be used to customise the behaviour
 - `OTF_SSH_KEY` - The private SSH key to use by default for all SSH connections. This is essential when using a basic docker container to trigger OTF. If not specified, it will default to use any private SSH keys available to the user executing the application.
 - `OTF_REMOTE_SCRIPT_BASE_DIR` - Alternative location to drop the temporary `transfer.py` script on remote hosts using SSH protocol. Default is `/tmp`
 - `OTF_STAGING_DIR` - Staging base directory to place files before they're dropped into their final location. Default is `/tmp`
+- `OTF_BATCH_RESUME_LOG_DATE` - Allow resuming of batch runs from a specific date. This is useful if you want to rerun a batch from a specific date, especially if the failure happens just after midnight and the date is no longer the same as the original run. Date format is `YYYYMMDD`
 
 ## Logging
 
@@ -359,6 +360,8 @@ Each task in a batch has an `order_id`, this is a unique ID for each task, and i
 `retry_on_rerun` is a boolean that determines whether a successful task is run a second time following a failed run. If a batch exits with a failure, and then the script is reun later on that same day, by default only the steps that failed will be run. All steps can be forced to run by setting this to true
 
 `timeout` specifies the number of seconds a task is allowed to be running before it gets terminated. This counts as a failure. The default timeout, if not specified is 300 seconds.
+
+As a batch task runs, it writes out the status of each sub task to it's log file. If a failure occurs, and the batch is rerun with the same arguments, it will attempt to resume from the point of failure. To determine the previous state, the batch handler will look at only logs that are from the current date. This is tp ensure that if something failed at 1am yesterday, but hasn't been rerun, we won't try to recover from the point of failure. Sometimes you might want to recover regardless, this can be done by passing in the date of the log files that you want to recover from, using the environment variable `OTF_BATCH_RESUME_LOG_DATE` in the format `YYYYMMDD`. This will instruct the batch handler to look at logs with that date instead.
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ In order for the process to run, you must have at least one task, and a `variabl
 
 These are some environment variables that can be used to customise the behaviour of the application. There are some internally used variables too, but changing them without a full understanding of the code is not advised.
 
-- `OTF_NO_LOG` - Disable logging to file. Only log to stderr
+- `OTF_NO_LOG` - Disable logging to file. Only log to stderr. Set to `1` to enable
+- `OTF_LOG_JSON` - Stderr logging will be in JSON format. Set to `1` to enable
 - `OTF_LOG_DIRECTORY` - Path under which log files are written
 - `OTF_RUN_ID` - (meant for internal use) An aggregator for log files. When set, all log files for a run will go under this sub directory. E.g. running a batch, all execution and transfer logs will be dropped into this sub directory, rather than a directory for each task name. This is equivalent to using `-r` or `--runId` command line arguments, which is generally preferred.
 - `OTF_SSH_KEY` - The private SSH key to use by default for all SSH connections. This is essential when using a basic docker container to trigger OTF. If not specified, it will default to use any private SSH keys available to the user executing the application.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -56,7 +56,7 @@ task-run = "opentaskpy.cli.task_run:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.11.0"
+current_version = "0.12.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -44,7 +44,7 @@ def main() -> None:
     if args.runId:
         os.environ["OTF_RUN_ID"] = args.runId
 
-    os.environ["OTF_LOG_RUN_PREFIX"] = datetime.now().strftime("%Y%m%d-%H%M%S.%f")
+    os.environ["OTF_LOG_RUN_PREFIX"] = datetime.now().strftime("%Y%m%d-%H%M%S.%f")[:-3]
 
     logging_level = logging.INFO
     if args.verbosity == 3:

--- a/src/opentaskpy/config/loader.py
+++ b/src/opentaskpy/config/loader.py
@@ -163,7 +163,7 @@ class ConfigLoader:
 
         # Check to see if this is not a batch type
         if "type" in task_definition and task_definition["type"] == "batch":
-            self.logger.warning("Cannot apply overrides to batch tasks. Ignoring")
+            self.logger.debug("Cannot apply overrides to batch tasks")
             return task_definition
 
         # Finally, attributes of the task definition can also be overridden by environment variables

--- a/src/opentaskpy/otflogging.py
+++ b/src/opentaskpy/otflogging.py
@@ -185,6 +185,21 @@ def get_latest_log_file(task_id: str, task_type: str) -> str | None:
         and re.match(r"\d{8}-\d{6}\.\d{3}", f.split("_")[0])
     ]
 
+    # Unless another date is given, only look at today's logs
+    batch_resume_date = datetime.now().date()
+    if os.environ.get("OTF_BATCH_RESUME_LOG_DATE") is None:
+        batch_resume_date = datetime.strptime(
+            os.environ.get("OTF_BATCH_RESUME_LOG_DATE"), "%Y%m%d"
+        ).date()
+
+    # Remove any logs that are not from the given date
+    log_files = [
+        f
+        for f in log_files
+        if datetime.strptime(f.split("_")[0], "%Y%m%d-%H%M%S.%f").date()
+        == batch_resume_date
+    ]
+
     # Sort the list by the date/time in the filename
     log_files.sort(key=lambda x: datetime.strptime(x.split("_")[0], "%Y%m%d-%H%M%S.%f"))
     # Get the latest log file

--- a/src/opentaskpy/otflogging.py
+++ b/src/opentaskpy/otflogging.py
@@ -187,7 +187,7 @@ def get_latest_log_file(task_id: str, task_type: str) -> str | None:
 
     # Unless another date is given, only look at today's logs
     batch_resume_date = datetime.now().date()
-    if os.environ.get("OTF_BATCH_RESUME_LOG_DATE") is None:
+    if os.environ.get("OTF_BATCH_RESUME_LOG_DATE"):
         batch_resume_date = datetime.strptime(
             os.environ.get("OTF_BATCH_RESUME_LOG_DATE"), "%Y%m%d"
         ).date()

--- a/src/opentaskpy/remotehandlers/local.py
+++ b/src/opentaskpy/remotehandlers/local.py
@@ -69,6 +69,10 @@ class LocalTransfer(RemoteTransferHandler):
         if not file_pattern:
             file_pattern = str(self.spec["fileRegex"])
 
+        self.logger.info(
+            f"Searching for files in {directory} with pattern {file_pattern}"
+        )
+
         self.logger.log(
             12,
             f"[LOCAL] Searching in {directory} for files with pattern {file_pattern}",

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -275,7 +275,20 @@ class SFTPTransfer(RemoteTransferHandler):
             mode = self.spec["mode"] if "mode" in self.spec else None
 
             try:
-                self.sftp_client.put(file, f"{destination_directory}/{file_name}")
+                # While writing, the file should not have it's final name. Replace the
+                # file extension with .partial, and then rename it once the file has
+                # been transferred
+                file_name_partial = re.sub(r"\.[^.]+$", ".partial", file_name)
+
+                self.sftp_client.put(
+                    file, f"{destination_directory}/{file_name_partial}"
+                )
+
+                # Rename the file to its final name
+                self.sftp_client.posix_rename(
+                    f"{destination_directory}/{file_name_partial}",
+                    f"{destination_directory}/{file_name}",
+                )
                 if mode:
                     self.sftp_client.chmod(
                         f"{destination_directory}/{file_name}", int(mode)

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -100,6 +100,7 @@ class SFTPTransfer(RemoteTransferHandler):
                 f"{__name__}.{os.environ.get('OTF_TASK_ID')}.paramiko.transport"
             )
             ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+            self.logger.info(f"Connecting to {hostname}")
             ssh_client.connect(**client_kwargs)
             self.sftp_client = ssh_client.open_sftp()
 
@@ -115,10 +116,7 @@ class SFTPTransfer(RemoteTransferHandler):
         """
         # Close connection
         if self.sftp_client:
-            self.logger.debug(
-                f"[{self.spec['hostname']}] Closing SFTP connection to"
-                f" {self.spec['hostname']}"
-            )
+            self.logger.info(f"[{self.spec['hostname']}] Closing SFTP connection to")
             self.sftp_client.close()
 
     def list_files(
@@ -139,6 +137,10 @@ class SFTPTransfer(RemoteTransferHandler):
             directory = str(self.spec["directory"])
         if not file_pattern:
             file_pattern = str(self.spec["fileRegex"])
+
+        self.logger.info(
+            f"Searching for files in {directory} with pattern {file_pattern}"
+        )
 
         self.logger.log(
             12,

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -117,6 +117,7 @@ class SSHTransfer(RemoteTransferHandler):
                 self.logger.info("Using key file from task spec")
                 kwargs["key_filename"] = self.spec["protocol"]["credentials"]["keyFile"]
 
+            self.logger.info(f"Connecting to {hostname}")
             ssh_client.connect(**kwargs)
             _, stdout, _ = ssh_client.exec_command("uname -a")  # nosec B601
             with stdout as stdout_fh:
@@ -157,12 +158,10 @@ class SSHTransfer(RemoteTransferHandler):
                 self.sftp_connection.remove(f"{REMOTE_SCRIPT_BASE_DIR}/transfer.py")
             self.sftp_connection.close()
 
-            self.logger.debug(
-                f"[{self.spec['hostname']}] Closing SSH connection to"
-                f" {self.spec['hostname']}"
-            )
+            self.logger.info(f"[{self.spec['hostname']}] Closing SFTP connection")
             self.sftp_connection.close()
         if self.ssh_client:
+            self.logger.info(f"[{self.spec['hostname']}] Closing SSH connection")
             self.ssh_client.close()
 
     def get_staging_directory(self, remote_spec: dict) -> str:
@@ -206,6 +205,10 @@ class SSHTransfer(RemoteTransferHandler):
             directory = str(self.spec["directory"])
         if not file_pattern:
             file_pattern = str(self.spec["fileRegex"])
+
+        self.logger.info(
+            f"Searching for files in {directory} with pattern {file_pattern}"
+        )
 
         self.logger.log(
             12,
@@ -584,6 +587,7 @@ class SSHTransfer(RemoteTransferHandler):
 
         stdin, stdout, stderr = self.ssh_client.exec_command(remote_command)  # type: ignore[union-attr] # nosec B601
 
+        self.logger.info("### START OF REMOTE OUTPUT ###")
         with stdout as stdout_fh:
             str_stdout = stdout_fh.read().decode("UTF-8")
             if str_stdout:
@@ -595,6 +599,8 @@ class SSHTransfer(RemoteTransferHandler):
                 self.logger.info(
                     f"[{self.spec['hostname']}] Remote stderr returned:\n{str_stderr}"
                 )
+
+        self.logger.info("### END OF REMOTE OUTPUT ###")
 
         remote_rc: int = stdout.channel.recv_exit_status()
         self.logger.info(
@@ -847,8 +853,8 @@ class SSHExecution(RemoteExecutionHandler):
 
     def tidy(self) -> None:
         """Tidy up the SSH connection."""
-        self.logger.debug(f"[{self.remote_host}] Closing SSH connection")
         if self.ssh_client:
+            self.logger.info(f"[{self.remote_host}] Closing SSH connection")
             self.ssh_client.close()
 
     def __init__(self, remote_host: str, spec: dict):

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -161,8 +161,9 @@ class SSHTransfer(RemoteTransferHandler):
                 f"[{self.spec['hostname']}] Closing SSH connection to"
                 f" {self.spec['hostname']}"
             )
-            if self.ssh_client:
-                self.ssh_client.close()
+            self.sftp_connection.close()
+        if self.ssh_client:
+            self.ssh_client.close()
 
     def get_staging_directory(self, remote_spec: dict) -> str:
         """Get the staging directory for the remote host.

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -57,6 +57,13 @@ class Batch(TaskHandler):
         previous_log_file = opentaskpy.otflogging.get_latest_log_file(
             self.task_id, TASK_TYPE
         )
+
+        self.logger.info(
+            f"Found previous log file: {previous_log_file}"
+            if previous_log_file
+            else "No previous log file found"
+        )
+
         previous_status = {}
         if previous_log_file:
             self.logger.info("Parsing previous log file for log marks")

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -427,10 +427,3 @@ class Batch(TaskHandler):
 
         self.logger.info(f"[{task_handler.task_id}] Returned {result}")
         return result
-
-    # Destructor to handle when the batch is finished. Make sure the log file
-    # gets renamed as appropriate
-    def __del__(self) -> None:
-        """Destructor to handle closing log file correctly."""
-        self.logger.debug("Batch object deleted")
-        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/src/opentaskpy/taskhandlers/execution.py
+++ b/src/opentaskpy/taskhandlers/execution.py
@@ -232,12 +232,3 @@ class Execution(TaskHandler):
         remote_host = self._get_remote_host_name(remote_handler)
         self.logger.info(f"[{remote_host}] Execution returned {result}")
         return result
-
-    # Destructor to handle when the execution is finished. Make sure the log file
-    # gets renamed as appropriate
-    def __del__(self) -> None:
-        """Destructor to handle closing log file correctly."""
-        self.logger.debug("Execution object deleted")
-        # Close the file handler
-        self.logger.info("Closing log file handler")
-        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/src/opentaskpy/taskhandlers/taskhandler.py
+++ b/src/opentaskpy/taskhandlers/taskhandler.py
@@ -42,6 +42,8 @@ class TaskHandler(ABC):
         if status == 0:
             self.overall_result = True
 
+        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)
+
         # Throw an exception if we have one
         if exception:
             if callable(exception):
@@ -133,7 +135,7 @@ class TaskHandler(ABC):
         # Create the remote handler from this class
         return addon_class(spec)
 
-    def __del__(self) -> None:
-        """Destructor."""
-        # Close the log file
-        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)
+    # def __del__(self) -> None:
+    #     """Destructor."""
+    #     # Close the log file
+    #     opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/src/opentaskpy/taskhandlers/taskhandler.py
+++ b/src/opentaskpy/taskhandlers/taskhandler.py
@@ -134,8 +134,3 @@ class TaskHandler(ABC):
 
         # Create the remote handler from this class
         return addon_class(spec)
-
-    # def __del__(self) -> None:
-    #     """Destructor."""
-    #     # Close the log file
-    #     opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/src/opentaskpy/taskhandlers/taskhandler.py
+++ b/src/opentaskpy/taskhandlers/taskhandler.py
@@ -42,10 +42,6 @@ class TaskHandler(ABC):
         if status == 0:
             self.overall_result = True
 
-        # Close the file handler
-        self.logger.info("Closing log file handler")
-        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)
-
         # Throw an exception if we have one
         if exception:
             if callable(exception):
@@ -136,3 +132,8 @@ class TaskHandler(ABC):
 
         # Create the remote handler from this class
         return addon_class(spec)
+
+    def __del__(self) -> None:
+        """Destructor."""
+        # Close the log file
+        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -594,11 +594,3 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 )
 
         return self.return_result(0)
-
-    # Destructor to handle when the transfer is finished. Make sure the log file
-    # gets renamed as appropriate
-    def __del__(self) -> None:
-        """Destructor to handle closing log file correctly."""
-        self.logger.debug("Transfer object deleted")
-        self.logger.info("Closing log file handler")
-        opentaskpy.otflogging.close_log_file(self.logger, self.overall_result)

--- a/tests/file_helper.py
+++ b/tests/file_helper.py
@@ -1,7 +1,10 @@
 # pylint: skip-file
 import logging
 import os
+import shutil
 from re import match
+
+import pytest
 
 BASE_DIRECTORY = "test/testFiles"
 
@@ -22,3 +25,19 @@ def list_test_files(directory, file_pattern, delimiter):
         if match(rf"{file_pattern}", f)
     ]
     return delimiter.join(files)
+
+
+@pytest.fixture(scope="function")
+def clear_logs() -> None:
+    """Clear the logs directory."""
+    if os.path.exists("logs"):
+        # Delete the files inside the logs directory
+        for file_name in os.listdir("logs"):
+            file_path = os.path.join("logs", file_name)
+            try:
+                if os.path.isfile(file_path):
+                    os.unlink(file_path)
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
+            except OSError:
+                pass

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,7 +11,7 @@ from tests.fixtures.ssh_clients import *  # noqa: F403
 
 def test_define_log_file_name(env_vars, tmpdir, top_level_root_dir):
     # Pass in different task types and validate that the log file name is correct
-    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{3}\.\d{6}"
+    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{6}\.\d{3}"
     log_path = "logs"
     expected_result_regex = rf"{log_path}/no_task_id/{timestamp}_B_running.log"
 
@@ -76,7 +76,7 @@ def test_define_log_file_name(env_vars, tmpdir, top_level_root_dir):
 def test_init_logging(env_vars, top_level_root_dir):
     # Call init logging function and ensure that the returned logger includes a TaskFileHandler
     # pointing at the correct filename
-    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{3}\.\d{6}"
+    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{6}\.\d{3}"
     log_path = f"{top_level_root_dir}/logs"
     expected_result_regex = rf"{log_path}/some_task_id/{timestamp}_running.log"
     logger = opentaskpy.otflogging.init_logging(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,7 +11,7 @@ from tests.fixtures.ssh_clients import *  # noqa: F403
 
 def test_define_log_file_name(env_vars, tmpdir, top_level_root_dir):
     # Pass in different task types and validate that the log file name is correct
-    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{6}\.\d{6}"
+    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{3}\.\d{6}"
     log_path = "logs"
     expected_result_regex = rf"{log_path}/no_task_id/{timestamp}_B_running.log"
 
@@ -76,7 +76,7 @@ def test_define_log_file_name(env_vars, tmpdir, top_level_root_dir):
 def test_init_logging(env_vars, top_level_root_dir):
     # Call init logging function and ensure that the returned logger includes a TaskFileHandler
     # pointing at the correct filename
-    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{6}\.\d{6}"
+    timestamp = datetime.now().strftime("%Y%m%d-") + r"\d{3}\.\d{6}"
     log_path = f"{top_level_root_dir}/logs"
     expected_result_regex = rf"{log_path}/some_task_id/{timestamp}_running.log"
     logger = opentaskpy.otflogging.init_logging(

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -240,6 +240,9 @@ def test_batch_timeout(setup_ssh_keys, env_vars, root_dir):
     log_file_name_batch = opentaskpy.otflogging._define_log_file_name("timeout", "B")
     log_file_name_task = opentaskpy.otflogging._define_log_file_name("sleep-300", "E")
 
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
+
     # Check that both exist, but renamed with _failed
     assert os.path.exists(log_file_name_batch.replace("_running", "_failed"))
     assert os.path.exists(log_file_name_task.replace("_running", "_failed"))
@@ -261,6 +264,9 @@ def test_batch_parallel_single_success(setup_ssh_keys, env_vars, root_dir):
     )
     # Run and expect a false status
     assert not batch_obj.run()
+
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
 
     # Validate that a log has been created with the correct status
     # Use the logging module to get the right log file name
@@ -293,6 +299,9 @@ def test_batch_resume_after_failure(setup_ssh_keys, env_vars, root_dir):
     # Run and expect a false status
     assert not batch_obj.run()
 
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
+
     # Validate that a log has been created with the correct status
     # Use the logging module to get the right log file name
     log_file_name_batch = opentaskpy.otflogging._define_log_file_name(task_id, "B")
@@ -323,6 +332,9 @@ def test_batch_resume_after_failure(setup_ssh_keys, env_vars, root_dir):
 
     # Run and expect a false status
     assert not batch_obj.run()
+
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
 
     # Validate that the touch task has been skipped, so there's no log file
     log_file_name_batch = opentaskpy.otflogging._define_log_file_name(task_id, "B")
@@ -355,6 +367,9 @@ def test_batch_resume_after_failure_retry_successful_tasks(
     )
     # Run and expect a false status
     assert not batch_obj.run()
+
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
 
     # Validate that a log has been created with the correct status
     # Use the logging module to get the right log file name
@@ -416,6 +431,9 @@ def test_batch_continue_on_failure(setup_ssh_keys, env_vars, root_dir):
     )
     # Run and expect a false status
     assert not batch_obj.run()
+
+    # Trash the batch_obj so that the log file is closed
+    del batch_obj
 
     # Validate that a log has been created with the correct status
     # Use the logging module to get the right log file name

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -11,6 +11,7 @@ from opentaskpy.config.loader import ConfigLoader
 
 # from opentaskpy.taskhandlers.batch import Batch
 from opentaskpy.taskhandlers import batch, execution, transfer
+from tests.file_helper import *  # noqa: F403
 from tests.fixtures.ssh_clients import *  # noqa: F403
 
 os.environ["OTF_NO_LOG"] = "1"
@@ -282,7 +283,7 @@ def test_batch_parallel_single_success(setup_ssh_keys, env_vars, root_dir):
     assert os.path.exists(log_file_name_failed_task.replace("_running", "_failed"))
 
 
-def test_batch_resume_after_failure(setup_ssh_keys, env_vars, root_dir):
+def test_batch_resume_after_failure(setup_ssh_keys, env_vars, root_dir, clear_logs):
     task_id = f"parallel-single-failure-1-{RANDOM}"
     # Ensure there are no logs for this batch
     shutil.rmtree(
@@ -401,6 +402,8 @@ def test_batch_resume_after_failure_retry_successful_tasks(
 
     # Run and expect a false status
     assert not batch_obj.run()
+
+    del batch_obj
 
     # Validate that the touch task has been skipped, so there's no log file
     log_file_name_batch = opentaskpy.otflogging._define_log_file_name(task_id, "B")


### PR DESCRIPTION
Closes #21 

- Added JSON formatter for logging to stderr. This replaces the default Python logging format with structured JSON output. This is enabled by setting the `OTF_LOG_JSON` environment variable to `1`. Log files are not impact, as these are always in standard format, as this is required for the batch log parsing to allow for rerunability.
- Tidy up logging
- Fix SSH transfers to ensure that SSH connections are fully closed after use
- Update SFTP transfers to use .partial file extension while files are being uploaded, and then rename them to their final name the transfer is complete.
- Altered log level for some messages
- Added `OTF_BATCH_RESUME_LOG_DATE` to allow resuming of batch runs from a specific date. This is useful if you want to rerun a batch from a specific date, especially if the failure happens just after midnight and the date is no longer the same as the original run.
