### PR TITLE
Fix issue with schema definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # v0.13.1
 
 - Fix protocol schemas to allow protocols other that SSH to actually be used for transfers
+- Add some more documentation to the `--help` output
 
 # v0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v0.13.1
+
+- Fix protocol schemas to allow protocols other that SSH to actually be used for transfers
+
 # v0.13.0
 
 - Add additional tests to improve coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "0.13.0"
+version = "0.13.1"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -58,7 +58,7 @@ task-run = "opentaskpy.cli.task_run:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.13.0"
+current_version = "0.13.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 from datetime import datetime
+from textwrap import dedent
 
 from opentaskpy import taskrun  # type: ignore[attr-defined]
 from opentaskpy.otflogging import OTF_LOG_FORMAT
@@ -15,7 +16,21 @@ CONFIG_PATH = f"{os.getcwd()}/cfg"
 
 def main() -> None:
     """Parse args and call TaskRun class."""
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog=dedent("""\
+                                Environment Variables:
+
+                                There are several environment variables that can be used to impact the behaviour:
+
+                                    OTF_RUN_ID - Equivalent to using --runId argument
+                                    OTF_LOG_JSON - Change the log output format to structured JSON format
+                                    OTF_NO_LOG - Prevent logging to any files, will log to stdout/err only
+                                    OTF_LOG_DIRECTORY - Specify a particular log directory to write log files to
+                                    OTF_LOG_LEVEL - Equivalent to using -v
+                                    OTF_SSH_KEY - Specify a particular SSH key to use for SSH/SFTP related transfers
+                                """),
+    )
     parser.add_argument(
         "-t", "--taskId", help="Name of the JSON config to run", type=str, required=True
     )
@@ -29,7 +44,15 @@ def main() -> None:
         type=str,
         required=False,
     )
-    parser.add_argument("-v", "--verbosity", help="Increase verbosity", type=int)
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        help=(
+            "Increase verbosity:\n10 - DEBUG\n11 - VERBOSE1\n12 - VERBOSE2\n20 -"
+            " INFO\n30 - WARN\n40 - ERROR"
+        ),
+        type=int,
+    )
     parser.add_argument(
         "-c", "--configDir", help="Directory containing task configurations", type=str
     )
@@ -82,4 +105,16 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
+    main()
     main()

--- a/src/opentaskpy/config/schemas/transfer/local_destination.json
+++ b/src/opentaskpy/config/schemas/transfer/local_destination.json
@@ -14,22 +14,22 @@
       "$ref": "http://localhost/transfer/local_destination/rename.json"
     },
     "permissions": {
-      "$ref": "http://localhost/transfer/ssh_destination/permissions.json"
+      "$ref": "http://localhost/transfer/local_destination/permissions.json"
     },
     "mode": {
       "type": "string"
     },
     "flags": {
-      "$ref": "http://localhost/transfer/ssh_destination/flags.json"
+      "$ref": "http://localhost/transfer/local_destination/flags.json"
     },
     "transferType": {
       "type": "string",
       "enum": ["push", "pull", "proxy"]
     },
     "protocol": {
-      "$ref": "http://localhost/transfer/ssh_destination/protocol.json"
+      "$ref": "http://localhost/transfer/local_destination/protocol.json"
     }
   },
   "additionalProperties": false,
-  "required": ["hostname", "directory", "protocol"]
+  "required": ["directory", "protocol"]
 }

--- a/src/opentaskpy/config/schemas/transfer/local_destination/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/local_destination/protocol.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["ssh"]
+      "enum": ["local"]
     }
   },
   "required": ["name"],

--- a/src/opentaskpy/config/schemas/transfer/local_source.json
+++ b/src/opentaskpy/config/schemas/transfer/local_source.json
@@ -26,5 +26,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["hostname", "directory", "fileRegex", "protocol"]
+  "required": ["directory", "fileRegex", "protocol"]
 }

--- a/src/opentaskpy/config/schemas/transfer/local_source/postCopyAction.json
+++ b/src/opentaskpy/config/schemas/transfer/local_source/postCopyAction.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://localhost/transfer/sftp_source/postCopyAction.json",
+  "$id": "http://localhost/transfer/local_source/postCopyAction.json",
   "type": "object",
   "properties": {
     "action": {

--- a/src/opentaskpy/config/schemas/transfer/local_source/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/local_source/protocol.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["ssh"]
+      "enum": ["local"]
     }
   },
   "required": ["name"],

--- a/src/opentaskpy/config/schemas/transfer/local_source/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/local_source/protocol.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://localhost/transfer/sftp_source/protocol.json",
+  "$id": "http://localhost/transfer/local_source/protocol.json",
   "type": "object",
   "properties": {
     "name": {

--- a/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["ssh"]
+      "enum": ["sftp"]
     },
     "credentials": {
       "type": "object",

--- a/src/opentaskpy/config/schemas/transfer/sftp_source/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/sftp_source/protocol.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "enum": ["ssh"]
+      "enum": ["sftp"]
     },
     "credentials": {
       "type": "object",

--- a/tests/test_schema_validate.py
+++ b/tests/test_schema_validate.py
@@ -59,6 +59,16 @@ def test_source_protocols(valid_source_definition):
     assert not validate_transfer_json(json_data)
 
 
+def test_local_source_protocol(valid_source_definition):
+    valid_source_definition["protocol"] = {"name": "local"}
+    json_data = {
+        "type": "transfer",
+        "source": valid_source_definition,
+        "destination": [],
+    }
+    assert validate_transfer_json(json_data)
+
+
 def test_dest_with_different_protocols(
     valid_source_definition,
     valid_destination_definition,

--- a/tests/test_schema_validate.py
+++ b/tests/test_schema_validate.py
@@ -61,6 +61,7 @@ def test_source_protocols(valid_source_definition):
 
 def test_local_source_protocol(valid_source_definition):
     valid_source_definition["protocol"] = {"name": "local"}
+    del valid_source_definition["hostname"]
     json_data = {
         "type": "transfer",
         "source": valid_source_definition,


### PR DESCRIPTION
Transfers that weren't using SSH prootcol couldn't be used due to bad schemas. Updated these so other protocols can actually be used.