### PR TITLE
Allow jinja2 template task definitions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,16 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Transfer - SSH Vars",
+      "type": "python",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": ["-t", "scp-basic-ssh-vars", "-c", "test/cfg", "-v", "10"],
+      "justMyCode": false
+    },
+    {
       "name": "Python: Transfer - Basic - JSON Logging",
       "type": "python",
       "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v0.14.0
+
+- Add mode override docs to `--help`
+- Allow task definitions to use a whole templated object within them. e.g a protocol definition could be defined as a global variable to define SFTP connectivity to a commonly used source/destination. This is done using `.j2` task definition file instead of `.json`
+
 # v0.13.1
 
 - Fix protocol schemas to allow protocols other that SSH to actually be used for transfers

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ options:
 
 **-t, --taskId**
 
-This relates to the specific task that you want to run. It is the name of the configuration file to load (without the .json suffix), contained under the `CONFIGDIR`
+This relates to the specific task that you want to run. It is the name of the configuration file to load (without the `.json` or `.json.j2` suffix), contained under the `CONFIGDIR`
 
 **-r, --runId**
 
@@ -231,6 +231,8 @@ Usage:
 Task definitions are validated using the JSON Schemas defined within `src/opentaskpy/config/schemas/`. These are split up to make them more readable. The top level schema for each task type is defined within the `schemas.py` file, one level above.
 
 At a later date, I plan to automate the creation of the JSON schema documentation.
+
+The task definitions themselves live under the `cfg` directory, and any number of sub directories under there to allow for grouping of tasks by whatever you like. Definitions can be either a plain JSON file, or a Jinja2 template. If a template is used, it must have the `.j2` suffix. JSON files may also use internal variables, this is not supported when using `.j2` task definitions.
 
 ## Transfers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "0.13.1"
+version = "0.14.0"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -58,7 +58,7 @@ task-run = "opentaskpy.cli.task_run:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.13.1"
+current_version = "0.14.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -29,6 +29,18 @@ def main() -> None:
                                     OTF_LOG_DIRECTORY - Specify a particular log directory to write log files to
                                     OTF_LOG_LEVEL - Equivalent to using -v
                                     OTF_SSH_KEY - Specify a particular SSH key to use for SSH/SFTP related transfers
+
+                                Task Definition Overrides:
+
+                                To override task specific values, you can use the following format in the environment variable name:
+                                OTF_OVERRIDE_<TASK_TYPE>_<ATTRIBUTE>_<ATTRIBUTE>_<ATTRIBUTE>
+
+                                e.g. OTF_OVERRIDE_TRANSFER_SOURCE_HOSTNAME
+
+                                Case doesn't matter here. For attributes that are nested within an array, you can specify the array index
+
+                                e.g. OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME
+
                                 """),
     )
     parser.add_argument(
@@ -105,16 +117,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
-    main()
     main()

--- a/test/cfg/transfers/scp-basic-ssh-vars.json.j2
+++ b/test/cfg/transfers/scp-basic-ssh-vars.json.j2
@@ -1,0 +1,21 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "{{ HOST_A }}",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": ".*\\.txt",
+    "protocol": {
+      "name": "ssh",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  },
+  "destination": [
+    {
+      "hostname": "{{ HOST_B }}",
+      "directory": "/tmp/testFiles/dest",
+      "protocol": {{ SSH_VARS| tojson }}
+    }
+  ]
+}

--- a/test/cfg/variables.json.j2
+++ b/test/cfg/variables.json.j2
@@ -23,5 +23,6 @@
   "PREV_YYYY": "{{ (now()|delta_days(-1)).strftime('%Y') }}",
   "testLookup": "{{ lookup('file', path='/tmp/variable_lookup.txt') }}",
   "testLookup2": "{{ lookup('http_json', url='https://jsonplaceholder.typicode.com/posts/1', jsonpath='$.title') }}",
-  "global_protocol_vars": {"name": "email", "smtp_port": 587, "smtp_server": "smtp.gmail.com"}
+  "global_protocol_vars": {"name": "email", "smtp_port": 587, "smtp_server": "smtp.gmail.com"},
+  "SSH_VARS": {"name": "ssh", "credentials": {"username": "someuser"}}
 }


### PR DESCRIPTION
- Add mode override docs to `--help`
- Allow task definitions to use a whole templated object within them. e.g a protocol definition could be defined as a global variable to define SFTP connectivity to a commonly used source/destination. This is done using `.j2` task definition file instead of `.json`