### PR TITLE
Fixes for no error and log renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v0.15.1
+
+- Fix issue with logs not renaming correctly when an exception is thrown that's not caught
+- Fix issue where `"error": false` for a transfer still caused the transfer to exit with a non-zero exit code
+
 # v0.15.0
 
 - Fix issue with chmods not actually working as intended

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -144,7 +144,16 @@ class SFTPTransfer(RemoteTransferHandler):
                 f" pattern {file_pattern}"
             ),
         )
-        remote_files = {}
+        remote_files: dict = {}
+        # Check the remote directory exists
+        try:
+            self.sftp_connection.stat(directory)  # type: ignore[union-attr]
+        except FileNotFoundError:
+            self.logger.error(
+                f"[{self.spec['hostname']}] Directory {directory} does not exist"
+            )
+            return remote_files
+
         remote_file_list = self.sftp_client.listdir(directory)  # type: ignore[union-attr]
         for file in list(remote_file_list):
             if re.match(file_pattern, file):

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -202,7 +202,16 @@ class SSHTransfer(RemoteTransferHandler):
                 f" pattern {file_pattern}"
             ),
         )
-        remote_files = {}
+        remote_files: dict = {}
+        # Check the remote directory exists
+        try:
+            self.sftp_connection.stat(directory)  # type: ignore[union-attr]
+        except FileNotFoundError:
+            self.logger.error(
+                f"[{self.spec['hostname']}] Directory {directory} does not exist"
+            )
+            return remote_files
+
         remote_file_list = self.sftp_connection.listdir(directory)  # type: ignore[union-attr]
         for file in list(remote_file_list):
             if re.match(file_pattern, file):

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -324,7 +324,6 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 )
 
         # Determine what needs to be transferred
-
         remote_files = self.source_remote_handler.list_files()
 
         # Loop through the returned files to see if they match the file age and size spec (if defined)
@@ -413,7 +412,6 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         "No remote files could be found to transfer. But not erroring"
                         " due to config"
                     ),
-                    exception=exceptions.FilesDoNotMeetConditionsError,
                 )
 
             return self.return_result(

--- a/src/opentaskpy/taskrun.py
+++ b/src/opentaskpy/taskrun.py
@@ -73,7 +73,10 @@ class TaskRun:  # pylint: disable=too-few-public-methods
 
             transfer = Transfer(global_variables, self.task_id, active_task_definition)
 
-            result = transfer.run()
+            try:
+                result = transfer.run()
+            except Exception as exception:  # pylint: disable=broad-except
+                transfer.return_result(1, str(exception), exception)
 
         elif active_task_definition["type"] == "execution":
             # Hand off to the execuiton module
@@ -91,8 +94,10 @@ class TaskRun:  # pylint: disable=too-few-public-methods
             execution = Execution(
                 global_variables, self.task_id, active_task_definition
             )
-
-            result = execution.run()
+            try:
+                result = execution.run()
+            except Exception as exception:  # pylint: disable=broad-except
+                execution.return_result(1, str(exception), exception)
 
         elif active_task_definition["type"] == "batch":
             # Hand off to the batch module
@@ -103,7 +108,10 @@ class TaskRun:  # pylint: disable=too-few-public-methods
                 active_task_definition,
                 self.config_loader,
             )
-            result = batch.run()
+            try:
+                result = batch.run()
+            except Exception as exception:  # pylint: disable=broad-except
+                batch.return_result(1, str(exception), exception)
 
         else:
             self.logger.error("Unknown task type!")

--- a/test/cfg/transfers/scp-basic-no-error-1.json
+++ b/test/cfg/transfers/scp-basic-no-error-1.json
@@ -1,0 +1,27 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "{{ HOST_A }}",
+    "directory": "/tmp/non-existent-dir",
+    "fileRegex": "non-existent-file-12345\\.txt",
+    "error": false,
+    "protocol": {
+      "name": "ssh",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  },
+  "destination": [
+    {
+      "hostname": "{{ HOST_B }}",
+      "directory": "/tmp/testFiles/dest",
+      "protocol": {
+        "name": "ssh",
+        "credentials": {
+          "username": "{{ SSH_USERNAME }}"
+        }
+      }
+    }
+  ]
+}

--- a/test/cfg/transfers/scp-basic-no-error.json
+++ b/test/cfg/transfers/scp-basic-no-error.json
@@ -1,0 +1,27 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "{{ HOST_A }}",
+    "directory": "/tmp",
+    "fileRegex": "non-existent-file-12345\\.txt",
+    "error": false,
+    "protocol": {
+      "name": "ssh",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  },
+  "destination": [
+    {
+      "hostname": "{{ HOST_B }}",
+      "directory": "/tmp/testFiles/dest",
+      "protocol": {
+        "name": "ssh",
+        "credentials": {
+          "username": "{{ SSH_USERNAME }}"
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_task_run.py
+++ b/tests/test_task_run.py
@@ -74,6 +74,18 @@ def test_scp_basic_binary(env_vars, setup_ssh_keys, root_dir):
     assert run_task_run("scp-basic")["returncode"] == 0
 
 
+def test_scp_basic_no_error_on_exit_binary(env_vars, setup_ssh_keys, root_dir):
+    # Use the "binary" to trigger the job with command line arguments
+
+    assert run_task_run("scp-basic-no-error")["returncode"] == 0
+
+
+def test_scp_basic_no_error_on_exit_binary_1(env_vars, setup_ssh_keys, root_dir):
+    # Use the "binary" to trigger the job with command line arguments
+
+    assert run_task_run("scp-basic-no-error-1")["returncode"] == 0
+
+
 def test_execution_basic_binary(env_vars, setup_ssh_keys, root_dir):
     # Use the "binary" to trigger the job with command line arguments
 


### PR DESCRIPTION
* Fix issue with logs not renaming correctly when an exception is thrown that's not caught
* Fix issue where `"error": false` for a transfer still caused the transfer to exit with a non-zero exit code