### PR TITLE
Importing modules in batch tasks fail when there's more than 2 tasks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
       - id: black
         stages: [manual]
         args:
-          - --preview
           - --check
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v0.15.2
+
+- Fix issue loading modules too fast with multiple steps in a batch
+
 # v0.15.1
 
 - Fix issue with logs not renaming correctly when an exception is thrown that's not caught

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "0.15.1"
+version = "0.15.2"
 authors = [
   { name="Adam McDonagh", email="adam@elitemonkey.net" },
 ]
@@ -58,7 +58,7 @@ task-run = "opentaskpy.cli.task_run:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "0.15.1"
+current_version = "0.15.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.11"
 dev = [
   "types-requests >=2.28",
   "types-paramiko >=3.0",
-  "black >= 23.1.0",
+  "black == 23.3.0",
   "isort",
   "pytest",
   "bumpver",

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -18,7 +18,8 @@ def main() -> None:
     """Parse args and call TaskRun class."""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        epilog=dedent("""\
+        epilog=dedent(
+            """\
                                 Environment Variables:
 
                                 There are several environment variables that can be used to impact the behaviour:
@@ -42,7 +43,8 @@ def main() -> None:
 
                                 e.g. OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME
 
-                                """),
+                                """
+        ),
     )
 
     parser.add_argument(

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -18,8 +18,7 @@ def main() -> None:
     """Parse args and call TaskRun class."""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        epilog=dedent(
-            """\
+        epilog=dedent("""\
                                 Environment Variables:
 
                                 There are several environment variables that can be used to impact the behaviour:
@@ -43,8 +42,7 @@ def main() -> None:
 
                                 e.g. OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME
 
-                                """
-        ),
+                                """),
     )
 
     parser.add_argument(

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -120,8 +120,10 @@ class SSHTransfer(RemoteTransferHandler):
             with stdout as stdout_fh:
                 self.logger.log(
                     11,
-                    f"[{self.spec['hostname']}] Remote uname:"
-                    f" {stdout_fh.read().decode('UTF-8')}",
+                    (
+                        f"[{self.spec['hostname']}] Remote uname:"
+                        f" {stdout_fh.read().decode('UTF-8')}"
+                    ),
                 )
 
             sftp = ssh_client.open_sftp()
@@ -196,8 +198,10 @@ class SSHTransfer(RemoteTransferHandler):
 
         self.logger.log(
             12,
-            f"[{self.spec['hostname']}] Searching in {directory} for files with"
-            f" pattern {file_pattern}",
+            (
+                f"[{self.spec['hostname']}] Searching in {directory} for files with"
+                f" pattern {file_pattern}"
+            ),
         )
         remote_files: dict = {}
         # Check the remote directory exists
@@ -779,8 +783,10 @@ class SSHTransfer(RemoteTransferHandler):
                     if re.search(self.spec["logWatch"]["contentRegex"], line.strip()):
                         self.logger.log(
                             12,
-                            f"[{self.spec['hostname']}] Found matching line in log:"
-                            f" {line.strip()} on line: {i+1}",
+                            (
+                                f"[{self.spec['hostname']}] Found matching line in log:"
+                                f" {line.strip()} on line: {i+1}"
+                            ),
                         )
                         return 0
 

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -2,6 +2,7 @@
 
 This module contains the SSH remote handlers for transfers and executions.
 """
+
 import glob
 import logging
 import os
@@ -119,10 +120,8 @@ class SSHTransfer(RemoteTransferHandler):
             with stdout as stdout_fh:
                 self.logger.log(
                     11,
-                    (
-                        f"[{self.spec['hostname']}] Remote uname:"
-                        f" {stdout_fh.read().decode('UTF-8')}"
-                    ),
+                    f"[{self.spec['hostname']}] Remote uname:"
+                    f" {stdout_fh.read().decode('UTF-8')}",
                 )
 
             sftp = ssh_client.open_sftp()
@@ -197,10 +196,8 @@ class SSHTransfer(RemoteTransferHandler):
 
         self.logger.log(
             12,
-            (
-                f"[{self.spec['hostname']}] Searching in {directory} for files with"
-                f" pattern {file_pattern}"
-            ),
+            f"[{self.spec['hostname']}] Searching in {directory} for files with"
+            f" pattern {file_pattern}",
         )
         remote_files: dict = {}
         # Check the remote directory exists
@@ -374,7 +371,9 @@ class SSHTransfer(RemoteTransferHandler):
         remote_user = quote(remote_user)
         remote_host = quote(remote_host)
 
-        remote_command = f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
+        remote_command = (
+            f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
+        )
         self.logger.info(
             f"[{self.spec['hostname']}] Transferring files via SCP: {remote_command}"
         )
@@ -781,10 +780,8 @@ class SSHTransfer(RemoteTransferHandler):
                     if re.search(self.spec["logWatch"]["contentRegex"], line.strip()):
                         self.logger.log(
                             12,
-                            (
-                                f"[{self.spec['hostname']}] Found matching line in log:"
-                                f" {line.strip()} on line: {i+1}"
-                            ),
+                            f"[{self.spec['hostname']}] Found matching line in log:"
+                            f" {line.strip()} on line: {i+1}",
                         )
                         return 0
 

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -371,9 +371,8 @@ class SSHTransfer(RemoteTransferHandler):
         remote_user = quote(remote_user)
         remote_host = quote(remote_host)
 
-        remote_command = (
-            f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
-        )
+        remote_command = f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
+
         self.logger.info(
             f"[{self.spec['hostname']}] Transferring files via SCP: {remote_command}"
         )

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -374,9 +374,7 @@ class SSHTransfer(RemoteTransferHandler):
         remote_user = quote(remote_user)
         remote_host = quote(remote_host)
 
-        remote_command = (
-            f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
-        )
+        remote_command = f'scp {SSH_OPTIONS} {" ".join(files)} {remote_user}@{remote_host}:"{destination_directory}"'
         self.logger.info(
             f"[{self.spec['hostname']}] Transferring files via SCP: {remote_command}"
         )

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -1,5 +1,4 @@
 """Batch task handler class."""
-
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
@@ -229,9 +228,11 @@ class Batch(TaskHandler):
                         if self.task_order_tree[dependency]["status"] != "COMPLETED":
                             self.logger.log(
                                 12,
-                                "Skipping task"
-                                f" {order_id} ({batch_task['task_id']}) as"
-                                f" dependency {dependency} has not completed",
+                                (
+                                    "Skipping task"
+                                    f" {order_id} ({batch_task['task_id']}) as"
+                                    f" dependency {dependency} has not completed"
+                                )
                             )
                             all_dependencies_complete = False
                             continue

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -1,4 +1,5 @@
 """Batch task handler class."""
+
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
@@ -228,11 +229,9 @@ class Batch(TaskHandler):
                         if self.task_order_tree[dependency]["status"] != "COMPLETED":
                             self.logger.log(
                                 12,
-                                (
-                                    "Skipping task"
-                                    f" {order_id} ({batch_task['task_id']}) as"
-                                    f" dependency {dependency} has not completed"
-                                ),
+                                "Skipping task"
+                                f" {order_id} ({batch_task['task_id']}) as"
+                                f" dependency {dependency} has not completed",
                             )
                             all_dependencies_complete = False
                             continue
@@ -263,6 +262,9 @@ class Batch(TaskHandler):
                     batch_task["start_time"] = time.time()
                     batch_task["thread"] = thread
                     batch_task["kill_event"] = e
+
+                    # Sleep 1 second to allow the thread to start
+                    time.sleep(1)
 
                 # Check if the task has completed
                 if batch_task["status"] == "RUNNING":

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -232,7 +232,7 @@ class Batch(TaskHandler):
                                     "Skipping task"
                                     f" {order_id} ({batch_task['task_id']}) as"
                                     f" dependency {dependency} has not completed"
-                                )
+                                ),
                             )
                             all_dependencies_complete = False
                             continue

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -485,9 +485,9 @@ def test_override_task_specific_attribute(write_dummy_variables_file, tmpdir):
     # Override things
     os.environ["OTF_OVERRIDE_TRANSFER_SOURCE_HOSTNAME"] = "non_existent_host"
     os.environ["OTF_OVERRIDE_TRANSFER_DESTINATION_0_HOSTNAME"] = "non_existent_host2"
-    os.environ[
-        "OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME"
-    ] = "my_username"
+    os.environ["OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME"] = (
+        "my_username"
+    )
 
     # Load the task definition
     config_loader = ConfigLoader(tmpdir)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -485,9 +485,9 @@ def test_override_task_specific_attribute(write_dummy_variables_file, tmpdir):
     # Override things
     os.environ["OTF_OVERRIDE_TRANSFER_SOURCE_HOSTNAME"] = "non_existent_host"
     os.environ["OTF_OVERRIDE_TRANSFER_DESTINATION_0_HOSTNAME"] = "non_existent_host2"
-    os.environ["OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME"] = (
-        "my_username"
-    )
+    os.environ[
+        "OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME"
+    ] = "my_username"
 
     # Load the task definition
     config_loader = ConfigLoader(tmpdir)


### PR DESCRIPTION
If theres 2 tasks in a batch that rely on the same external addon, if they try and load too quickly you get partially loaded package errors.
Added a sleep between tasks in a batch so they don't start up so quickly and the package has time to load into memory.