### PR TITLE
Allways call return_result for exceptions thrown by batch task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.9.0
+
+- Fix timed out batch and transfer logging to ensure that the log file is closed correctly
+
 # v24.8.0
 
 - Update `--noop` to work correctly for batch

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -469,8 +469,10 @@ class Batch(TaskHandler):
         try:
             result = task_handler.run(kill_event=event)
         except Exception as ex:  # pylint: disable=broad-exception-caught
+            task_handler.return_result(1, str(ex), ex)
             self.logger.error(f"[{task_handler.task_id}] Failed to run task")
-            self.logger.error(ex)
+            # Log the call stack
+            self.logger.exception(ex)
             result = False
 
         self.logger.info(f"[{task_handler.task_id}] Returned {result}")

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -112,6 +112,9 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
             shutil.rmtree(self.local_staging_dir)
 
         # Call super to do the rest
+        # Log the exception
+        if exception:
+            self.logger.exception(exception)
         return super().return_result(status, message, exception)  # type: ignore[no-any-return]
 
     def _get_default_class(self, protocol_name: str) -> type:
@@ -294,6 +297,9 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     actual_sleep_seconds = remaining_seconds
                 else:
                     actual_sleep_seconds = sleep_seconds
+
+                # Prevent negative sleep times
+                actual_sleep_seconds = max(actual_sleep_seconds, 0)
 
                 self.logger.info(
                     f"No files found. Sleeping for {sleep_seconds} secs."


### PR DESCRIPTION
Fixes #52 
Ensure that exceptions get output properly
Also ensure exceptions thrown by a batchtask are caught by the batch itself and the result_result is always called against the task handler to ensure that the log gets renamed