### PR TITLE
Prevent local files being moved to staging directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix timed out batch and transfer logging to ensure that the log file is closed correctly
 - Reorder log format to bring log level to the front
 - Add retry logic to SSH based connections
+- Prevent local based transfers from using the staging directory
 
 # v24.8.0
 

--- a/src/opentaskpy/remotehandlers/local.py
+++ b/src/opentaskpy/remotehandlers/local.py
@@ -184,7 +184,6 @@ class LocalTransfer(RemoteTransferHandler):
 
             try:
                 shutil.copy(file, final_destination)
-                os.remove(file)
                 if mode:
                     os.chmod(final_destination, int(mode, base=8))
             except Exception as ex:  # pylint: disable=broad-exception-caught

--- a/src/opentaskpy/remotehandlers/local.py
+++ b/src/opentaskpy/remotehandlers/local.py
@@ -105,8 +105,11 @@ class LocalTransfer(RemoteTransferHandler):
     ) -> int:
         """Pull files to the worker.
 
-        Moves files from a local location, to the staging directory. This will be used
-        for uploading files to the destination server.
+        This is not applicable for a local transfer, since the files are local already.
+        The files will not be transferred as they'll just fill up the worker's disk for
+        no reason.
+
+        All args are not used because this function literally does nothing.
 
         Args:
             files (list): A list of files to download.
@@ -114,28 +117,9 @@ class LocalTransfer(RemoteTransferHandler):
             into.
 
         Returns:
-            int: 0 if successful, 1 if not.
+            int: Always returns 0
         """
-        result = 0
-
-        # Create the staging directory locally
-        if not os.path.exists(local_staging_directory):
-            os.makedirs(local_staging_directory)
-
-        # Download the files via SFTP
-        for file in files:
-            self.logger.info(
-                f"[LOCALHOST] Copying file {file} to {local_staging_directory}"
-            )
-            file_name = os.path.basename(file)
-            try:
-                # Move file on disk
-                shutil.copy2(file, f"{local_staging_directory}/{file_name}")
-            except Exception as ex:  # pylint: disable=broad-exception-caught
-                self.logger.error(f"[LOCALHOST] Failed to copy file locally: {ex}")
-                result = 1
-
-        return result
+        return 0
 
     def push_files_from_worker(self, local_staging_directory: str) -> int:
         """Push files from the worker to another local directory.

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -71,7 +71,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         if "OTF_STAGING_DIR" in environ:
             self.local_staging_dir = f"{environ['OTF_STAGING_DIR']}/{staging_dir_name}"
         else:
-            self.local_staging_dir = f"/{DEFAULT_STAGING_DIR_BASE}/{staging_dir_name}"
+            self.local_staging_dir = f"{DEFAULT_STAGING_DIR_BASE}/{staging_dir_name}"
 
         self.logger = opentaskpy.otflogging.init_logging(
             "opentaskpy.taskhandlers.transfer", self.task_id, TASK_TYPE
@@ -104,12 +104,20 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 self.logger.log(12, f"Closing dest connection for {remote_handler}")
                 remote_handler.tidy()
 
-        # Remove local staging directory if it exists
-        if path.exists(self.local_staging_dir):
+        # Remove local staging directory if it exists (and this isn't a local transfer)
+        if (
+            path.exists(self.local_staging_dir)
+            and self.local_staging_dir != self.source_file_spec["directory"]
+        ):
             self.logger.log(
                 12, f"Removing local staging directory {self.local_staging_dir}"
             )
             shutil.rmtree(self.local_staging_dir)
+        else:
+            self.logger.log(
+                12,
+                "Local staging directory is the same as source directory. Not removing",
+            )
 
         # Call super to do the rest
         # Log the exception
@@ -472,8 +480,11 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     )
                     or not self.source_remote_handler.supports_direct_transfer()
                 ):
-                    # Create local staging dir
-                    makedirs(self.local_staging_dir, exist_ok=True)
+                    # Create local staging dir (if this isn't using the local protocol)
+                    if self.source_file_spec["protocol"]["name"] != "local":
+                        makedirs(self.local_staging_dir, exist_ok=True)
+                    else:
+                        self.local_staging_dir = self.source_file_spec["directory"]
                     transfer_result = self.source_remote_handler.pull_files_to_worker(
                         remote_files, self.local_staging_dir
                     )

--- a/test/cfg/transfers/local-basic.json
+++ b/test/cfg/transfers/local-basic.json
@@ -1,0 +1,15 @@
+{
+  "type": "transfer",
+  "source": {
+    "directory": "/tmp/src",
+    "fileRegex": ".*basic.*\\.txt",
+    "protocol": { "name": "local" }
+  },
+  "destination": [
+    {
+      "directory": "/tmp/dest",
+      "protocol": { "name": "local" },
+      "mode": "0644"
+    }
+  ]
+}

--- a/tests/test_task_run.py
+++ b/tests/test_task_run.py
@@ -109,6 +109,17 @@ def test_batch_basic_binary(env_vars, setup_ssh_keys, root_dir):
     assert run_task_run("batch-basic")["returncode"] == 0
 
 
+def test_transfer_local_binary(env_vars, root_dir):
+    # Create a test_basic_local.txt file in /tmp/src
+    fs.create_files([{"/tmp/src/test_basic_local.txt": {"content": "test1234"}}])
+    # Ensure /tmp/dest exists
+    if not os.path.exists("/tmp/dest"):
+        os.makedirs("/tmp/dest")
+
+    # Use the "binary" to trigger the job with command line arguments
+    assert run_task_run("local-basic")["returncode"] == 0
+
+
 def test_batch_execution_invalid_host(env_vars, setup_ssh_keys, root_dir):
     # Use the "binary" to trigger the job with command line arguments
 


### PR DESCRIPTION
There's no reason to use the staging directory for local files. If the source procotol is local, then the step will be skipped, and also the step that removes the staging directory will be skipped.

Fixes #39.