### PR TITLE
Fix timeout issue in batch transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.11.0
+
+- Fix an issue with batches not killing transfers when the task times out
+
 # v24.10.0
 
 - Update otflogging to be more thread safe when closing log file

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -220,6 +220,11 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
             start_time = time.time()
             found_log_entry = False
             while floor(time.time() - start_time) <= timeout_seconds:
+                if kill_event and kill_event.is_set():
+                    return self.return_result(
+                        1, "KILLED DUE TO TIMEOUT FROM PARENT BATCH"
+                    )
+
                 if self.source_remote_handler.do_logwatch() == 0:
                     found_log_entry = True
                     break
@@ -277,6 +282,11 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
             while (
                 not remote_files and floor(time.time() - start_time) <= timeout_seconds
             ):
+                if kill_event and kill_event.is_set():
+                    return self.return_result(
+                        1, "KILLED DUE TO TIMEOUT FROM PARENT BATCH"
+                    )
+
                 remote_files = self.source_remote_handler.list_files(
                     directory=watch_directory, file_pattern=watch_file_pattern
                 )

--- a/test/cfg/transfers/filewatch-300.json
+++ b/test/cfg/transfers/filewatch-300.json
@@ -1,0 +1,18 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "{{ HOST_A }}",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": "non-existent-file1234\\.log",
+    "fileWatch": {
+      "timeout": 600,
+      "fileRegex": "non-existent-file1234\\.txt"
+    },
+    "protocol": {
+      "name": "ssh",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  }
+}

--- a/test/cfg/transfers/filewatch-local-300.json
+++ b/test/cfg/transfers/filewatch-local-300.json
@@ -1,0 +1,14 @@
+{
+  "type": "transfer",
+  "source": {
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": "non-existent-file1234\\.log",
+    "fileWatch": {
+      "timeout": 600,
+      "fileRegex": "non-existent-file1234\\.txt"
+    },
+    "protocol": {
+      "name": "local"
+    }
+  }
+}


### PR DESCRIPTION
This pull request fixes an issue with batch transfers where the tasks were not being killed when they timed out. The timeout behavior has been updated to properly handle the timeout and kill the tasks.