### PR TITLE
Replace `now` Jinja function with `utc_now`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.14.0
+
+- Replace existing `now` Jinja function with `utc_now`. This always returns the UTC time. `now` will always return the localtime of the machine running the task instead.
+
 # v24.13.1
 
 - Fix an issue where local transfers were still deleting the source directory when tidying up the staging area, causing post copy actions to fail too

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Usage:
 "fileRegex": "somefile.*{{ YYYY }}\\.txt"
 ```
 
+`now` is added by OTF, it will return a `datetime` object aligned to whatever timezone the worker is running. If you need the UTC time, then you can use `utc_now` instead.
+
 # Task Definitions
 
 Task definitions are validated using the JSON Schemas defined within `src/opentaskpy/config/schemas/`. These are split up to make them more readable. The top level schema for each task type is defined within the `schemas.py` file, one level above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.13.1"
+version = "v24.14.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -70,7 +70,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.13.1"
+current_version = "v24.14.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "ruff",
     "coverage",
     "pytest-cov",
+    "freezegun",
 ]
 
 [project.urls]

--- a/src/opentaskpy/config/loader.py
+++ b/src/opentaskpy/config/loader.py
@@ -246,7 +246,8 @@ class ConfigLoader:
 
                 template = self.template_env.from_string(json_content)
 
-            template.globals["now"] = datetime.datetime.utcnow
+            template.globals["utc_now"] = self.now_utc
+            template.globals["now"] = self.now_localtime
 
             # Define lookup function
             template.globals["lookup"] = self.template_lookup
@@ -295,6 +296,14 @@ class ConfigLoader:
 
         self.global_variables = global_variables
 
+    def now_localtime(self) -> datetime.datetime:
+        """Return the current time in the local timezone."""
+        return datetime.datetime.now().astimezone()
+
+    def now_utc(self) -> datetime.datetime:
+        """Return the current time in UTC."""
+        return datetime.datetime.utcnow()
+
     # RESOLVE ANY VARIABLES THAT USE OTHER VARIABLES IN THE VARIABLE FILES
     def _resolve_templated_variables(self) -> None:
         # We need to evaluate the variables themselves, in case there's any recursion
@@ -305,8 +314,8 @@ class ConfigLoader:
         template = self.global_variables
 
         variables_template = self.template_env.from_string(json.dumps(template))
-        variables_template.globals["utc_now"] = datetime.datetime.utcnow
-        variables_template.globals["now"] = datetime.datetime.now().astimezone
+        variables_template.globals["utc_now"] = self.now_utc
+        variables_template.globals["now"] = self.now_localtime
 
         # Define lookup function
         variables_template.globals["lookup"] = self.template_lookup

--- a/src/opentaskpy/config/loader.py
+++ b/src/opentaskpy/config/loader.py
@@ -305,7 +305,8 @@ class ConfigLoader:
         template = self.global_variables
 
         variables_template = self.template_env.from_string(json.dumps(template))
-        variables_template.globals["now"] = datetime.datetime.utcnow
+        variables_template.globals["utc_now"] = datetime.datetime.utcnow
+        variables_template.globals["now"] = datetime.datetime.now().astimezone
 
         # Define lookup function
         variables_template.globals["lookup"] = self.template_lookup

--- a/src/opentaskpy/remotehandlers/remotehandler.py
+++ b/src/opentaskpy/remotehandlers/remotehandler.py
@@ -58,7 +58,9 @@ class RemoteTransferHandler(RemoteHandler):
         """
 
     @abstractmethod
-    def push_files_from_worker(self, local_staging_directory: str) -> int:
+    def push_files_from_worker(
+        self, local_staging_directory: str, file_list: dict | None = None
+    ) -> int:
         """Push files from the worker to the remote location.
 
         This is used when files have been either generated on the worker, or copied
@@ -66,6 +68,7 @@ class RemoteTransferHandler(RemoteHandler):
 
         Args:
             local_staging_directory (str): The local staging directory.
+            file_list (dict, optional): The list of files to transfer. Defaults to None.
 
         Returns:
             int: The result of the transfer. 0 for success, 1 for failure.


### PR DESCRIPTION
This pull request replaces the existing `now` Jinja function with `utc_now` in order to always return the UTC time. The `now` function will now return the localtime of the machine running the task instead.