### PR TITLE
New `supportsStatAfterUpload` SFTP protocol option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v24.17.0
+
+- Add protocol option for SFTP destination - `supportsStatAfterUpload` - When set to false this will prevent `stat` being run after upload. This helps when certain custom SFTP servers do not allow you to see your uploaded file, or they move it out of the way as soon as it's written to.
+- Minor update to SFTP transfer when uploading to `/` to prevent destination path starting with `//`
+
 # No release
 
 - Updated linting rules and some formatting in the tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.17.1
+
+- Fix issue where PCA when encrypting files would only handle the encrypted file(s), and not the original file(s)
+
 # v24.17.0
 
 - Add protocol option for SFTP destination - `supportsStatAfterUpload` - When set to false this will prevent `stat` being run after upload. This helps when certain custom SFTP servers do not allow you to see your uploaded file, or they move it out of the way as soon as it's written to.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.17.0"
+version = "v24.17.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -70,7 +70,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.17.0"
+current_version = "v24.17.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.14.0"
+version = "v24.17.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -70,7 +70,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.14.0"
+current_version = "v24.17.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
@@ -14,6 +14,10 @@
       "type": "boolean",
       "default": true
     },
+    "supportsStatAfterUpload": {
+      "type": "boolean",
+      "default": true
+    },
     "credentials": {
       "type": "object",
       "properties": {

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -328,6 +328,15 @@ class SFTPTransfer(RemoteTransferHandler):
 
             mode = self.spec.get("mode", None)
 
+            stat_after_upload = True
+            if not self.spec["protocol"].get("supportsStatAfterUpload", True):
+                stat_after_upload = False
+
+            # If destination directory is the root, then set it to an empty string
+            # so paths don't start with //
+            if destination_directory == "/":
+                destination_directory = ""
+
             try:
 
                 # Check the protocol to see if supportsPosixRename is set
@@ -339,7 +348,9 @@ class SFTPTransfer(RemoteTransferHandler):
                     file_name_partial = re.sub(r"\.[^.]+$", ".partial", file_name)
 
                     self.sftp_client.put(
-                        file, f"{destination_directory}/{file_name_partial}"
+                        file,
+                        f"{destination_directory}/{file_name_partial}",
+                        confirm=stat_after_upload,
                     )
 
                     # Rename the file to its final name
@@ -349,7 +360,11 @@ class SFTPTransfer(RemoteTransferHandler):
                     )
                 else:
                     # Upload the file without using a temporary name
-                    self.sftp_client.put(file, f"{destination_directory}/{file_name}")
+                    self.sftp_client.put(
+                        file,
+                        f"{destination_directory}/{file_name}",
+                        confirm=stat_after_upload,
+                    )
 
                 if mode:
                     self.sftp_client.chmod(

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -344,6 +344,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         remote_files = self.source_remote_handler.list_files(
             directory=source_directory, file_pattern=source_file_pattern
         )
+        decrypted_files = {}
+        encrypted_files = {}
 
         # Loop through the returned files to see if they match the file age and size spec (if defined)
         if "conditionals" in self.source_file_spec and remote_files:
@@ -506,7 +508,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 )
 
             original_file_list = remote_files.copy()
-            decrypted_files = {}
+
             # If it's requested and decryption is possible, then we need to decrypt the files
             if decryption_requested and can_do_encryption:
                 self.logger.info("Decrypting files")
@@ -520,7 +522,6 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 decrypted_files = remote_files.copy()
 
             i = 0
-            encrypted_files = {}
             for dest_file_spec in self.dest_file_specs:
                 encryption_requested = (
                     "encryption" in dest_file_spec

--- a/tests/test_task_run.py
+++ b/tests/test_task_run.py
@@ -357,6 +357,10 @@ def test_scp_file_watch(env_vars, setup_ssh_keys, root_dir):
         [{f"{root_dir}/testFiles/ssh_1/src/fileWatch.log": {"content": "01234567890"}}]
     )
 
+    # Ensure the source file doesn't exist
+    if os.path.exists(f"{root_dir}/testFiles/ssh_1/src/fileWatch.txt"):
+        os.remove(f"{root_dir}/testFiles/ssh_1/src/fileWatch.txt")
+
     # Filewatch configured to wait 15 seconds before giving up. Expect it to fail
     task_runner = taskrun.TaskRun("scp-file-watch", "test/cfg")
     assert not task_runner.run()

--- a/tests/test_taskhandler_transfer_local.py
+++ b/tests/test_taskhandler_transfer_local.py
@@ -633,8 +633,8 @@ def test_local_decrypt_incoming_file(
     transfer_obj = transfer.Transfer(None, "local-decrypt", local_task_definition_copy)
     assert transfer_obj.run()
 
-    # Check the source files have been deleted
-    assert not os.path.exists(f"{tmpdir}/test.decryption.txt.gpg")
+    # Check the decrypted source files have been deleted
+    assert not os.path.exists(f"{tmpdir}/test.decryption.txt")
 
     # Check the output file exists
     assert os.path.exists(f"{local_test_dir}/dest/test.decryption.txt")

--- a/tests/test_taskhandler_transfer_local.py
+++ b/tests/test_taskhandler_transfer_local.py
@@ -701,6 +701,9 @@ def test_local_encrypt_outgoing_file(
         new_file_checksum = hashlib.md5(f.read()).hexdigest()
     assert new_file_checksum == original_file_checksum
 
+    # Ensure that the source encrypted file has been deleted
+    assert not os.path.exists(f"{local_test_dir}/src/test.encryption.txt.gpg")
+
 
 def test_transfer_decryption_failure_local(
     tmpdir, root_dir, setup_local_test_dir, private_key_2, public_key

--- a/tests/test_taskhandler_transfer_local.py
+++ b/tests/test_taskhandler_transfer_local.py
@@ -633,6 +633,9 @@ def test_local_decrypt_incoming_file(
     transfer_obj = transfer.Transfer(None, "local-decrypt", local_task_definition_copy)
     assert transfer_obj.run()
 
+    # Check the source files have been deleted
+    assert not os.path.exists(f"{tmpdir}/test.decryption.txt.gpg")
+
     # Check the output file exists
     assert os.path.exists(f"{local_test_dir}/dest/test.decryption.txt")
     # Check that the file's checksum matches that of the original unencrypted source file

--- a/tests/test_taskhandler_transfer_sftp.py
+++ b/tests/test_taskhandler_transfer_sftp.py
@@ -369,6 +369,34 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
         f"{root_dir}/testFiles/sftp_2/dest/{random_number}/test.taskhandler.txt"
     )
 
+    # Finally run again, but set supportsStatAfterUpload to false in the protocol definition
+    sftp_task_definition["destination"][0]["protocol"][
+        "supportsStatAfterUpload"
+    ] = False
+
+    # Delete the destination file
+    os.remove(f"{root_dir}/testFiles/sftp_2/dest/{random_number}/test.taskhandler.txt")
+
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+
+    # Run the transfer and expect a true status
+    assert transfer_obj.run()
+
+    # Check the destination file exists
+    assert os.path.exists(
+        f"{root_dir}/testFiles/sftp_2/dest/{random_number}/test.taskhandler.txt"
+    )
+
+    # Change the destination directory to / and validate that it works
+    sftp_task_definition["destination"][0]["directory"] = "/"
+
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+
+    # Run the transfer and expect a false status, because it cannot write to / on the remote
+    # Expect a RemoteTransferError
+    with pytest.raises(exceptions.RemoteTransferError):
+        transfer_obj.run()
+
 
 def test_sftp_basic_key_from_protocol_definition(root_dir, sftp_key_file):
     # Create a test file

--- a/tests/test_taskhandler_transfer_sftp.py
+++ b/tests/test_taskhandler_transfer_sftp.py
@@ -2,6 +2,7 @@
 # ruff: noqa
 import os
 import random
+from copy import deepcopy
 
 import pytest
 from pytest_shell import fs
@@ -313,8 +314,9 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
         ]
     )
 
+    sftp_task_definition_copy = deepcopy(sftp_task_definition)
     # Create a transfer object
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a true status
     assert transfer_obj.run()
@@ -324,11 +326,11 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
     # Generate a random number
     random_number = random.randint(1, 1000000)
     # Test transferring to a subdir that doesn't exist, and creating it
-    sftp_task_definition["destination"][0][
+    sftp_task_definition_copy["destination"][0][
         "directory"
     ] = f"/home/application/testFiles/dest/{random_number}"
 
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a false status, as we've not asked the directory to be created
     # Expect a RemoteTransferError
@@ -341,9 +343,9 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
 
     # Now run again, but ask for the dir to be created
 
-    sftp_task_definition["destination"][0]["createDirectoryIfNotExists"] = True
+    sftp_task_definition_copy["destination"][0]["createDirectoryIfNotExists"] = True
 
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a true status
     assert transfer_obj.run()
@@ -354,12 +356,14 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
     )
 
     # Now run again, but set supportsPosixRename to false in the protocol definition
-    sftp_task_definition["destination"][0]["protocol"]["supportsPosixRename"] = False
+    sftp_task_definition_copy["destination"][0]["protocol"][
+        "supportsPosixRename"
+    ] = False
 
     # Delete the destination file
     os.remove(f"{root_dir}/testFiles/sftp_2/dest/{random_number}/test.taskhandler.txt")
 
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a true status
     assert transfer_obj.run()
@@ -370,14 +374,14 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
     )
 
     # Finally run again, but set supportsStatAfterUpload to false in the protocol definition
-    sftp_task_definition["destination"][0]["protocol"][
+    sftp_task_definition_copy["destination"][0]["protocol"][
         "supportsStatAfterUpload"
     ] = False
 
     # Delete the destination file
     os.remove(f"{root_dir}/testFiles/sftp_2/dest/{random_number}/test.taskhandler.txt")
 
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a true status
     assert transfer_obj.run()
@@ -388,9 +392,9 @@ def test_sftp_basic(root_dir, setup_sftp_keys):
     )
 
     # Change the destination directory to / and validate that it works
-    sftp_task_definition["destination"][0]["directory"] = "/"
+    sftp_task_definition_copy["destination"][0]["directory"] = "/"
 
-    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition)
+    transfer_obj = transfer.Transfer(None, "sftp-basic", sftp_task_definition_copy)
 
     # Run the transfer and expect a false status, because it cannot write to / on the remote
     # Expect a RemoteTransferError


### PR DESCRIPTION
This pull request updates the SFTP transfer to add a new protocol option called "supportsStatAfterUpload" which allows the user to prevent the "stat" command from being run after upload. 

Additionally, it fixes a minor issue where the destination path would start with "//" when uploading to the root directory.