### PR TITLE
Add option to sign encrypted files using a private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.18.0
+
+- Add the option to sign encrypted files using a private key, by setting `"sign": true`, and supplying the `private_key` property.
+
 # v24.17.3
 
 - Fix issue where using decryption meant that the encrypted file was also transferred to the destination.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.17.3"
+version = "v24.18.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -70,7 +70,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.17.3"
+current_version = "v24.18.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/schemas/transfer/encryption.json
+++ b/src/opentaskpy/config/schemas/transfer/encryption.json
@@ -4,10 +4,16 @@
   "type": "object",
   "properties": {
     "decrypt": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "encrypt": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
+    },
+    "sign": {
+      "type": "boolean",
+      "default": false
     },
     "private_key": {
       "type": "string"
@@ -15,6 +21,17 @@
     "public_key": {
       "type": "string"
     }
+  },
+  "if": {
+    "required": ["sign"],
+    "properties": {
+      "sign": {
+        "enum": [true]
+      }
+    }
+  },
+  "then": {
+    "required": ["private_key"]
   },
   "additionalProperties": false
 }

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -553,6 +553,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
                     # Get the public key from the spec
                     public_key = dest_file_spec["encryption"]["public_key"]
+                    private_key = None
+
                     if (
                         "sign" in dest_file_spec["encryption"]
                         and dest_file_spec["encryption"]["sign"]

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -553,6 +553,11 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
                     # Get the public key from the spec
                     public_key = dest_file_spec["encryption"]["public_key"]
+                    if (
+                        "sign" in dest_file_spec["encryption"]
+                        and dest_file_spec["encryption"]["sign"]
+                    ):
+                        private_key = dest_file_spec["encryption"]["private_key"]
 
                     # For each file in the remote_files list, alter the path to start
                     # with the local staging directory instead
@@ -564,7 +569,9 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         ] = remote_files[file]
 
                     # Loop through each file and encrypt it using gnupg
-                    remote_files = self.encrypt_files(local_files, public_key)
+                    remote_files = self.encrypt_files(
+                        local_files, public_key, private_key
+                    )
 
                     encrypted_files = remote_files.copy()
 
@@ -727,12 +734,15 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
         return self.return_result(0)
 
-    def encrypt_files(self, files: dict, public_key: str) -> dict:
+    def encrypt_files(
+        self, files: dict, public_key: str, private_key: str | None = None
+    ) -> dict:
         """Encrypt files using GPG.
 
         Args:
             files (dict): Dictionary of files to encrypt.
             public_key (str): Public key to use for encryption.
+            private_key (str, optional): Private key to use to sign the files. Defaults to None.
 
         Returns:
             dict: Dictionary of encrypted files.
@@ -749,6 +759,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
         # Load the public key
         import_result = gpg.import_keys(public_key)
+
         # Check the key imported OK
         if not import_result.count or import_result.count == 0:
             self.logger.error("Error importing public key")
@@ -756,6 +767,18 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
         # Get the fingerprint of the key we just imported
         key_fingerprint = gpg.list_keys()[0]["fingerprint"]
+        signing_key = None
+
+        if private_key:
+            # Load the private key
+            import_result = gpg.import_keys(private_key)
+
+            # Check the key imported OK
+            if not import_result.count or import_result.count == 0:
+                self.logger.error("Error importing private key")
+                raise exceptions.EncryptionError("Error importing private key")
+
+            signing_key = import_result.fingerprints[0]
 
         encrypted_files = {}
         for file in files:
@@ -770,6 +793,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     recipients=key_fingerprint,
                     output=output_filename,
                     always_trust=True,
+                    sign=signing_key,
                 )
 
                 # Check whether the encryption worked

--- a/tests/test_schema_validate.py
+++ b/tests/test_schema_validate.py
@@ -87,3 +87,36 @@ def test_dest_with_different_protocols(
     json_data["destination"].append(valid_destination_definition_2)
 
     assert validate_transfer_json(json_data)
+
+
+def test_encryption_with_public_key(valid_source_definition):
+
+    valid_source_definition["encryption"] = {"public_key": "blah", "encrypt": True}
+
+    json_data = {
+        "type": "transfer",
+        "source": valid_source_definition,
+        "destination": [],
+    }
+
+    assert validate_transfer_json(json_data)
+
+    # Set sign to true and dont add a private key, expect a failure
+    valid_source_definition["encryption"]["sign"] = True
+    json_data = {
+        "type": "transfer",
+        "source": valid_source_definition,
+        "destination": [],
+    }
+
+    assert not validate_transfer_json(json_data)
+
+    # Add a private key
+    valid_source_definition["encryption"]["private_key"] = "blah"
+    json_data = {
+        "type": "transfer",
+        "source": valid_source_definition,
+        "destination": [],
+    }
+
+    assert validate_transfer_json(json_data)


### PR DESCRIPTION
This pull request adds the option to sign encrypted files using a private key. It introduces a new property called "sign" in the encryption configuration, which can be set to true to enable signing. Additionally, a "private_key" property is required when signing is enabled. This feature enhances the security of encrypted files by providing a way to verify their authenticity.