### PR TITLE
Transfers not exiting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
         "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
         "python.defaultInterpreterPath": "/usr/local/bin/python",
         "python.testing.unittestEnabled": false,
-        "python.testing.pytestArgs": ["."],
+        "python.testing.pytestArgs": ["-s", "."],
         "python.analysis.typeCheckingMode": "off",
         "files.associations": {
           "*.json": "jsonc"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,6 +57,16 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Batch x15",
+      "type": "python",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": ["-t", "batch-15-sftp", "-c", "test/cfg", "-v3"],
+      "justMyCode": false
+    },
+    {
       "name": "Python: Transfer - Multiple",
       "type": "python",
       "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
   "python.defaultInterpreterPath": "/usr/local/bin/python",
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestArgs": ["."],
+  "python.testing.pytestArgs": ["-rx", "-s", "."],
   "python.analysis.typeCheckingMode": "off",
   "black-formatter.args": ["--preview"],
   "files.associations": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.19.1
+
+- Add additional timeout values for SFTP connections - Attempting to fix [#68](https://github.com/adammcdonagh/open-task-framework/issues/68)
+
 # v24.19.0
 
 - When creating directories, ensure entire path is created recursively rather than just attempting to create rightmost path part

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -17,9 +17,6 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 import opentaskpy.otflogging
 from opentaskpy.remotehandlers.remotehandler import RemoteTransferHandler
 
-SSH_OPTIONS: str = "-o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=5"
-REMOTE_SCRIPT_BASE_DIR: str = "/tmp"  # nosec B108
-
 
 class SFTPTransfer(RemoteTransferHandler):
     """SFTP Transfer Handler."""
@@ -123,6 +120,12 @@ class SFTPTransfer(RemoteTransferHandler):
             )
             ssh_client.set_missing_host_key_policy(AutoAddPolicy())
             self.logger.info(f"Connecting to {client_kwargs['hostname']}")
+
+            # Set additional timeout options to match the standard timeout
+            client_kwargs["banner_timeout"] = client_kwargs["timeout"]
+            client_kwargs["auth_timeout"] = client_kwargs["timeout"]
+            client_kwargs["channel_timeout"] = client_kwargs["timeout"]
+
             ssh_client.connect(**client_kwargs)
             self.sftp_client = ssh_client.open_sftp()
 

--- a/test/cfg/batch/batch-15-sftp.json
+++ b/test/cfg/batch/batch-15-sftp.json
@@ -1,0 +1,80 @@
+{
+  "type": "batch",
+  "tasks": [
+    {
+      "order_id": 1,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 2,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 3,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 4,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 5,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 6,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 7,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 8,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 9,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 10,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 11,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 12,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 13,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 14,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    },
+    {
+      "order_id": 15,
+      "task_id": "filewatch-300-sftp",
+      "timeout": 100
+    }
+  ]
+}

--- a/test/cfg/transfers/filewatch-300-sftp.json
+++ b/test/cfg/transfers/filewatch-300-sftp.json
@@ -1,0 +1,18 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "172.16.0.21",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": "non-existent-file1234\\.log",
+    "fileWatch": {
+      "timeout": 600,
+      "fileRegex": "non-existent-file1234\\.txt"
+    },
+    "protocol": {
+      "name": "sftp",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  }
+}

--- a/test/setupSSHKeys.sh
+++ b/test/setupSSHKeys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Get current script directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -31,3 +31,17 @@ docker exec ssh_1 /bin/sh -c "chown -R application ~application/.ssh && chmod -R
 docker cp $DIR/testFiles/id_rsa ssh_2:/home/application/.ssh
 docker cp $DIR/testFiles/id_rsa.pub ssh_2:/home/application/.ssh/authorized_keys
 docker exec ssh_2 /bin/sh -c "chown -R application ~application/.ssh && chmod -R 700 ~application/.ssh && chown -R application /tmp/testFiles"
+
+
+docker exec sftp_1 /bin/sh -c "usermod -G operator -a application -u $UID"
+docker exec sftp_2 /bin/sh -c "usermod -G operator -a application -u $UID"
+docker exec sftp_1 /bin/sh -c "mkdir -p ~application/.ssh"
+docker exec sftp_2 /bin/sh -c "mkdir -p ~application/.ssh"
+
+docker cp $DIR/testFiles/id_rsa sftp_1:/home/application/.ssh
+docker cp $DIR/testFiles/id_rsa.pub sftp_1:/home/application/.ssh/authorized_keys
+docker exec sftp_1 /bin/sh -c "chown -R application ~application/.ssh && chmod -R 700 ~application/.ssh && chown -R application /home/application/testFiles"
+
+docker cp $DIR/testFiles/id_rsa sftp_2:/home/application/.ssh
+docker cp $DIR/testFiles/id_rsa.pub sftp_2:/home/application/.ssh/authorized_keys
+docker exec sftp_2 /bin/sh -c "chown -R application ~application/.ssh && chmod -R 700 ~application/.ssh && chown -R application /home/application/testFiles"


### PR DESCRIPTION
Trying to help prevent #68. Unfortunately I cannot replicate it on demand. 

* Added a test batch of 15x filewatches doing an SFTP. 
* Ran the batches and while it was running manually terminated an SSH connection from the sftp_1 container. This caused OTF to detect the connection was closed and still worked just fine, and cleanly exited once all other steps had timed out.

Will have to monitor for any more occurrences in future. Propose running all transfers in verbose 3 mode so there's more chance of catching the issue if it happens again