### PR TITLE
v24.21.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
         "ms-python.isort",
         "yzhang.markdown-all-in-one",
         "ms-python.pylint",
-        "matangover.mypy",
+        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "ms-python.black-formatter",
         "tamasfe.even-better-toml",
@@ -39,6 +39,8 @@
       "settings": {
         "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
         "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "pylint.path": ["python", "-m", "pylint"],
+        "pylint.lintOnChange": true,
         "python.testing.unittestEnabled": false,
         "python.testing.pytestArgs": ["-s", "."],
         "python.analysis.typeCheckingMode": "off",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+# v24.21.0
+
 # v24.19.1
 
 - Add additional timeout values for SFTP connections - Attempting to fix [#68](https://github.com/adammcdonagh/open-task-framework/issues/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v24.21.0
 
+- Fix WRAPPER log file to ensure it closes when a child task fails due to an Exception - Fixes [#81](https://github.com/adammcdonagh/open-task-framework/issues/81)
 - Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
 - When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # v24.21.0
 
+- Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
+- When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion
+
 # v24.19.1
 
 - Add additional timeout values for SFTP connections - Attempting to fix [#68](https://github.com/adammcdonagh/open-task-framework/issues/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v24.21.0
 
+- Fixed renaming encrypted files when uploading via SFTP - Fixes [#79](https://github.com/adammcdonagh/open-task-framework/issues/79)
 - Fix WRAPPER log file to ensure it closes when a child task fails due to an Exception - Fixes [#81](https://github.com/adammcdonagh/open-task-framework/issues/81)
 - Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
 - When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.19.1"
+version = "v24.21.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -70,7 +70,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.19.1"
+current_version = "v24.21.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pytest-shell",
     "lovely-pytest-docker",
     "pre-commit",
-    "pylint >= 2.17.0",
+    "pylint >= 3.2.2",
     "pydantic",
     "mypy",
     "ruff",

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -132,6 +132,8 @@ def main() -> None:
         result = task_run_obj.run()
     except Exception as ex:  # pylint: disable=broad-exception-caught
         logger.error(f"Error running task: {ex}")
+        # Ensure that the log is closed
+        opentaskpy.otflogging.close_log_file(logger, False)
         if logger.getEffectiveLevel() <= 12:
             raise ex
         sys.exit(1)

--- a/src/opentaskpy/config/schemas/transfer/encryption.json
+++ b/src/opentaskpy/config/schemas/transfer/encryption.json
@@ -11,6 +11,10 @@
       "type": "boolean",
       "default": false
     },
+    "output_extension": {
+      "type": "string",
+      "default": "gpg"
+    },
     "sign": {
       "type": "boolean",
       "default": false

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -627,6 +627,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     if (
                         self.source_file_spec["protocol"]["name"] != "local"
                         and not decryption_requested
+                        and not encryption_requested
                     ):
                         transfer_result = (
                             associated_dest_remote_handler.push_files_from_worker(

--- a/test/cfg/transfers/sftp-timeout.json
+++ b/test/cfg/transfers/sftp-timeout.json
@@ -1,0 +1,27 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "localhost",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": ".*\\.txt",
+    "protocol": {
+      "name": "sftp",
+      "port": 1234,
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  },
+  "destination": [
+    {
+      "hostname": "{{ HOST_B }}",
+      "directory": "/tmp/testFiles/dest",
+      "protocol": {
+        "name": "ssh",
+        "credentials": {
+          "username": "{{ SSH_USERNAME }}"
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_docker_task_run.py
+++ b/tests/test_docker_task_run.py
@@ -279,5 +279,5 @@ def test_standard_docker_image(
     # We dont care whether this worked or not, we just want to check the logs
     # Check that the log file exists containing scp-basic in the name in log_dir
     log_files = os.listdir(f"{log_dir}/docker_log_test")
-    assert len(log_files) == 1
+    assert len(log_files) == 2
     assert "scp-basic" in log_files[0]


### PR DESCRIPTION
- Fixed renaming encrypted files when uploading via SFTP - Fixes [#79](https://github.com/adammcdonagh/open-task-framework/issues/79)
- Fix WRAPPER log file to ensure it closes when a child task fails due to an Exception - Fixes [#81](https://github.com/adammcdonagh/open-task-framework/issues/81)
- Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
- When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion