### PR TITLE
Allow choice of file extension for encryption

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
         "ms-python.isort",
         "yzhang.markdown-all-in-one",
         "ms-python.pylint",
-        "matangover.mypy",
+        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "ms-python.black-formatter",
         "tamasfe.even-better-toml",
@@ -39,6 +39,8 @@
       "settings": {
         "python.testing.unittestArgs": ["-v", "-s", "tests", "-p", "test_*.py"],
         "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "pylint.path": ["python", "-m", "pylint"],
+        "pylint.lintOnChange": true,
         "python.testing.unittestEnabled": false,
         "python.testing.pytestArgs": ["-s", "."],
         "python.analysis.typeCheckingMode": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # v24.21.0
 
+- Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
+- When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion
+
 # v24.19.1
 
 - Add additional timeout values for SFTP connections - Attempting to fix [#68](https://github.com/adammcdonagh/open-task-framework/issues/68)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pytest-shell",
     "lovely-pytest-docker",
     "pre-commit",
-    "pylint >= 2.17.0",
+    "pylint >= 3.2.2",
     "pydantic",
     "mypy",
     "ruff",

--- a/src/opentaskpy/config/schemas/transfer/encryption.json
+++ b/src/opentaskpy/config/schemas/transfer/encryption.json
@@ -11,6 +11,10 @@
       "type": "boolean",
       "default": false
     },
+    "output_extension": {
+      "type": "string",
+      "default": "gpg"
+    },
     "sign": {
       "type": "boolean",
       "default": false

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -570,9 +570,12 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                             f"{self.local_staging_dir}/{path.basename(file)}"
                         ] = remote_files[file]
 
+                    extension = dest_file_spec["encryption"].get(
+                        "output_extension", "gpg"
+                    )
                     # Loop through each file and encrypt it using gnupg
                     remote_files = self.encrypt_files(
-                        local_files, public_key, private_key
+                        local_files, public_key, private_key, extension
                     )
 
                     encrypted_files = remote_files.copy()
@@ -737,7 +740,11 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         return self.return_result(0)
 
     def encrypt_files(
-        self, files: dict, public_key: str, private_key: str | None = None
+        self,
+        files: dict,
+        public_key: str,
+        private_key: str | None = None,
+        extension: str = "gpg",
     ) -> dict:
         """Encrypt files using GPG.
 
@@ -745,6 +752,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
             files (dict): Dictionary of files to encrypt.
             public_key (str): Public key to use for encryption.
             private_key (str, optional): Private key to use to sign the files. Defaults to None.
+            extension (str, optional): Extension to add to the encrypted files. Defaults to "gpg".
 
         Returns:
             dict: Dictionary of encrypted files.
@@ -787,7 +795,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
             # If the filename contains .gpg on the end, then the output file will be just that but without the extension,
             # if it doesn't contain .gpg, then we'll add .gpg to the end
-            output_filename = f"{file}.gpg"
+            output_filename = f"{file}.{extension}"
 
             with open(file, "rb") as input_file:
                 encryption_data = gpg.encrypt_file(
@@ -846,10 +854,12 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         decrypted_files = {}
         for file in files:
 
-            # If the filename contains .gpg on the end, then the output file will be just that but without the extension,
-            # if it doesn't contain .gpg, then we'll add .decrypted to the end
+            # If the filename contains .gpg or .pgp on the end, then the output file will be just that but without the extension,
+            # if it doesn't contain .gpg or .pgp, then we'll add .decrypted to the end
             output_filename = (
-                file.replace(".gpg", "") if ".gpg" in file else f"{file}.decrypted"
+                file.replace(".gpg", "").replace(".pgp", "")
+                if file.endswith((".gpg", ".pgp"))
+                else f"{file}.decrypted"
             )
 
             self.logger.info(f"Decrypting {file} to {output_filename}")

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -435,6 +435,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
             self.logger.info(f" * {file}")
 
         can_do_encryption = False
+        original_file_list = remote_files.copy()
         # If there's a destination file spec, then we need to transfer the files
         if self.dest_file_specs:
             # Loop through all dest_file specs and see if there are any transfers where the source and dest protocols are different
@@ -507,8 +508,6 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     "Decryption requested but not supported for this transfer",
                     exception=exceptions.DecryptionNotSupportedError,
                 )
-
-            original_file_list = remote_files.copy()
 
             # If it's requested and decryption is possible, then we need to decrypt the files
             if decryption_requested and can_do_encryption:

--- a/tests/test_docker_task_run.py
+++ b/tests/test_docker_task_run.py
@@ -279,5 +279,5 @@ def test_standard_docker_image(
     # We dont care whether this worked or not, we just want to check the logs
     # Check that the log file exists containing scp-basic in the name in log_dir
     log_files = os.listdir(f"{log_dir}/docker_log_test")
-    assert len(log_files) == 1
+    assert len(log_files) == 2
     assert "scp-basic" in log_files[0]


### PR DESCRIPTION
Previously, the file extension for encrypted files was hardcoded as `.gpg`. This pull request introduces a new configuration option called `output_extension` that allows users to choose a different file extension for encrypted files. This is particularly useful for companies that use `.pgp` instead of `.gpg`.

Fixes #82