### PR TITLE
Fix WRAPPER log not closing on SFTP timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v24.21.0
 
+- Fix WRAPPER log file to ensure it closes when a child task fails due to an Exception - Fixes [#81](https://github.com/adammcdonagh/open-task-framework/issues/81)
 - Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
 - When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion
 

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -132,6 +132,8 @@ def main() -> None:
         result = task_run_obj.run()
     except Exception as ex:  # pylint: disable=broad-exception-caught
         logger.error(f"Error running task: {ex}")
+        # Ensure that the log is closed
+        opentaskpy.otflogging.close_log_file(logger, False)
         if logger.getEffectiveLevel() <= 12:
             raise ex
         sys.exit(1)

--- a/test/cfg/transfers/sftp-timeout.json
+++ b/test/cfg/transfers/sftp-timeout.json
@@ -1,0 +1,27 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "localhost",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": ".*\\.txt",
+    "protocol": {
+      "name": "sftp",
+      "port": 1234,
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  },
+  "destination": [
+    {
+      "hostname": "{{ HOST_B }}",
+      "directory": "/tmp/testFiles/dest",
+      "protocol": {
+        "name": "ssh",
+        "credentials": {
+          "username": "{{ SSH_USERNAME }}"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes issue #81.

Prevents the WRAPPER log from not renaming to `_failed` if the child tasks raise an exception