### PR TITLE
Fixes unencrypted files being transferred

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # v24.21.0
 
+- Fixed renaming encrypted files when uploading via SFTP - Fixes [#79](https://github.com/adammcdonagh/open-task-framework/issues/79)
 - Fix WRAPPER log file to ensure it closes when a child task fails due to an Exception - Fixes [#81](https://github.com/adammcdonagh/open-task-framework/issues/81)
 - Allow different file extension for encrypted files. Added `output_extension` to allow a different file extension for GPG encrypted files, instead of the default `.gpg`
 - When decrypting, handle both .gpg and .pgp file extensions by default before reverting to .decrypted exetnsion

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -627,6 +627,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     if (
                         self.source_file_spec["protocol"]["name"] != "local"
                         and not decryption_requested
+                        and not encryption_requested
                     ):
                         transfer_result = (
                             associated_dest_remote_handler.push_files_from_worker(


### PR DESCRIPTION
Looked like files were not getting renamed from the original report, but turned out to be a misconfiguration. However on looking deeper in some instances the unencrypted of the file was somehow getting uploaded too. 

Ensure that the corrent file list gets passed to the SFTP handler when doing encryption.

Fixes #79.