### PR TITLE
Add cacheable variables support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -66,6 +66,16 @@
           "editor.defaultFormatter": "ms-python.black-formatter"
         }
       }
+    },
+    "codespaces": {
+      "repositories": {
+        "adammcdonagh/otf-addons-aws": {
+          "permissions": "write-all"
+        },
+        "adammcdonagh/otf-addons-o365": {
+          "permissions": "write-all"
+        }
+      }
     }
   }
   // Configure tool-specific properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.22.0
+
+- Added new `cacheableVariables` option for transfers. This allows you to specify a list of variables that should be cached and written back to somewhere (depending on the `cachingPlugin` referenced). This is useful for dynamically updated variables that need to be stored centrally. For more detail see the `README.md`ß
+
 # v24.21.0
 
 - Fixed renaming encrypted files when uploading via SFTP - Fixes [#79](https://github.com/adammcdonagh/open-task-framework/issues/79)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# v24.22.0
+# v24.23.0
 
 - Added new `cacheableVariables` option for transfers. This allows you to specify a list of variables that should be cached and written back to somewhere (depending on the `cachingPlugin` referenced). This is useful for dynamically updated variables that need to be stored centrally. For more detail see the `README.md`ß
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,4 @@ coverage:
 
 ignore:
   - "tests/*"
+  - "src/opentaskpy/remotehandlers/dummy.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.21.0"
+version = "v24.23.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.21.0"
+current_version = "v24.23.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "referencing >= 0.29.1",
     "tenacity >= 8.2.3",
     "python-gnupg >= 0.5.2",
+    "omegaconf >= 2.3.0"
 ]
 description = "A framework for automation execution of commands and transferring files between hosts"
 readme = "README.md"

--- a/src/opentaskpy/config/schemas.py
+++ b/src/opentaskpy/config/schemas.py
@@ -54,7 +54,6 @@ TRANSFER_SCHEMA = {
         "variables": {"type": "object"},
     },
     "required": ["type", "source"],
-    "additionalProperties": False,
 }
 
 # Determine the type of transfer, and apply the correct sub schema based on the protocol used
@@ -74,7 +73,6 @@ EXECUTION_SCHEMA = {
         "variables": {"type": "object"},
     },
     "required": ["type", "protocol"],
-    "additionalProperties": False,
 }
 
 # Declare a constant that cannot be changed
@@ -91,7 +89,6 @@ BATCH_SCHEMA = {
         },
     },
     "required": ["type", "tasks"],
-    "additionalProperties": False,
 }
 
 logger = opentaskpy.otflogging.init_logging(__name__)

--- a/src/opentaskpy/config/schemas.py
+++ b/src/opentaskpy/config/schemas.py
@@ -47,10 +47,6 @@ TRANSFER_SCHEMA = {
                 "required": ["protocol"],
             },
         },
-        "cacheableVariables": {
-            "type": "array",
-            "items": {"$ref": "http://localhost/cacheable_variables.json"},
-        },
         "variables": {"type": "object"},
     },
     "required": ["type", "source"],

--- a/src/opentaskpy/config/schemas/cacheable_variables.json
+++ b/src/opentaskpy/config/schemas/cacheable_variables.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://localhost/cacheable_variables.json",
+  "type": "object",
+  "properties": {
+    "variableName": {
+      "type": "string",
+      "description": "The name of the variable in the JSON schema to be cached. Use dot notation to access nested properties."
+    },
+    "cachingPlugin": {
+      "type": "string",
+      "description": "The cache plugin to use for caching the variable. This can be 'file' or refer to a custom cache plugin."
+    },
+    "cacheArgs": {
+      "type": "object",
+      "description": "Arguments to pass to the cache plugin. This can be used to configure the cache plugin."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["variableName", "cachingPlugin", "cacheArgs"]
+}

--- a/src/opentaskpy/config/schemas/transfer/dummy_source.json
+++ b/src/opentaskpy/config/schemas/transfer/dummy_source.json
@@ -8,6 +8,10 @@
     },
     "protocol": {
       "$ref": "http://localhost/transfer/dummy_source/protocol.json"
+    },
+    "cacheableVariables": {
+      "type": "array",
+      "items": { "$ref": "http://localhost/cacheable_variables.json" }
     }
   },
   "additionalProperties": false,

--- a/src/opentaskpy/config/schemas/transfer/dummy_source.json
+++ b/src/opentaskpy/config/schemas/transfer/dummy_source.json
@@ -1,0 +1,15 @@
+{
+  "$id": "http://localhost/transfer/ssh_source.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "accessToken": {
+      "type": "string"
+    },
+    "protocol": {
+      "$ref": "http://localhost/transfer/dummy_source/protocol.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["accessToken", "protocol"]
+}

--- a/src/opentaskpy/config/schemas/transfer/dummy_source/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/dummy_source/protocol.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://localhost/transfer/dummy_source/protocol.json",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": ["dummy"]
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/src/opentaskpy/config/variablecaching/cache_utils.py
+++ b/src/opentaskpy/config/variablecaching/cache_utils.py
@@ -1,0 +1,36 @@
+"""Utility functions for caching variables."""
+
+from importlib import import_module
+
+DEFAULT_CACHE_PLUGINS = ["file"]
+
+
+def update_cache(cacheable_variable: dict, updated_value: str) -> None:
+    """Update the cache with the new value.
+
+    Args:
+        cacheable_variable (dict): The cacheable variable to update.
+        updated_value (str): The new value to update the cache with.
+
+    Returns:
+        None
+    """
+    # Now find and call the appropriate caching plugin
+    handler_package = None
+    if cacheable_variable["cachingPlugin"] in DEFAULT_CACHE_PLUGINS:
+        handler_package = (
+            f"opentaskpy.config.variablecaching.{cacheable_variable['cachingPlugin']}"
+        )
+
+    else:
+        handler_package = (
+            f"opentaskpy.variablecaching.{cacheable_variable['cachingPlugin']}"
+        )
+
+    # Call the run method of the handler_package, getting the actual function first
+    handler_function = getattr(import_module(handler_package), "run")
+
+    # Call the function
+    kwargs = cacheable_variable["cacheArgs"]
+    kwargs["value"] = updated_value
+    handler_function(**kwargs)

--- a/src/opentaskpy/config/variablecaching/file.py
+++ b/src/opentaskpy/config/variablecaching/file.py
@@ -1,0 +1,41 @@
+"""File caching plugin.
+
+This is a basic caching plugin that when given a value, and path to a file, will update it with the new value
+"""
+
+import opentaskpy.otflogging
+from opentaskpy.exceptions import CachingPluginError
+
+logger = opentaskpy.otflogging.init_logging(__name__)
+
+CACHE_NAME = "file"
+
+
+def run(**kwargs):  # type: ignore[no-untyped-def]
+    """Update a file with a new value.
+
+    Args:
+        **kwargs: Expect kwargs named file, and value. This should be the file to write
+        to, and the value to put into the file
+
+    Raises:
+        CachingPluginError: Returned if the kwarg 'file' or 'value' is not provided
+        FileNotFoundException: Returned if unable to write to the destination
+    """
+    # Expect a kwarg named file
+    expected_kwargs = ["file", "value"]
+    for kwarg in expected_kwargs:
+        if kwarg not in kwargs:
+            raise CachingPluginError(
+                f"Missing kwarg: '{kwarg}' while trying to run caching plugin"
+                f" '{CACHE_NAME}'"
+            )
+
+    # Write the value to the file
+    try:
+        with open(kwargs["file"], "w", encoding="utf-8") as file_:
+            file_.write(kwargs["value"])
+            logger.log(12, f"Wrote '{kwargs['value']}' to file {kwargs['file']}")
+    except FileNotFoundError as e:
+        logger.error(f"Unable to write to file {kwargs['file']}. Error: {e}")
+        raise e

--- a/src/opentaskpy/exceptions.py
+++ b/src/opentaskpy/exceptions.py
@@ -83,6 +83,14 @@ class LookupPluginError(Exception):
         super().__init__(message)
 
 
+class CachingPluginError(Exception):
+    """Caching plugin error."""
+
+    def __init__(self, message):
+        """Call the base class constructor."""
+        super().__init__(message)
+
+
 class VariableResolutionTooDeepError(Exception):
     """Variable resolution too deep error."""
 

--- a/src/opentaskpy/remotehandlers/dummy.py
+++ b/src/opentaskpy/remotehandlers/dummy.py
@@ -26,7 +26,7 @@ class DummyTransfer(RemoteTransferHandler):
 
         # Pretend that this handler does something, and gets a new accessToken, we need
         # to update the cache with this new value
-        self.spec["source"]["accessToken"] = randint(1, 100000)
+        self.spec["accessToken"] = randint(1, 100000)
 
         # If there's cacheable variables, handle them
         if "cacheableVariables" in spec:

--- a/src/opentaskpy/remotehandlers/dummy.py
+++ b/src/opentaskpy/remotehandlers/dummy.py
@@ -1,0 +1,123 @@
+"""Dummy Handler.
+
+This module doesn't actually do anything, it's just used for testing the cacheable
+variables.
+"""
+
+from random import randint
+
+from opentaskpy.config.variablecaching import cache_utils
+from opentaskpy.remotehandlers.remotehandler import RemoteTransferHandler
+
+
+class DummyTransfer(RemoteTransferHandler):
+    """Dummy Transfer Handler."""
+
+    TASK_TYPE = "T"
+
+    def __init__(self, spec: dict):
+        """Initialise the handler.
+
+        Args:
+            spec (dict): The spec for the transfer. This is either the source, or the
+            destination spec.
+        """
+        super().__init__(spec)
+
+        # Pretend that this handler does something, and gets a new accessToken, we need
+        # to update the cache with this new value
+        self.spec["source"]["accessToken"] = randint(1, 100000)
+
+        # If there's cacheable variables, handle them
+        if "cacheableVariables" in spec:
+            self.handle_cacheable_variables()
+
+    def handle_cacheable_variables(self) -> None:
+        """Handle the cacheable variables."""
+        # Obtain the "updated" value from the spec
+        for cacheable_variable in self.spec["cacheableVariables"]:
+
+            updated_value = self.obtain_variable_from_spec(
+                cacheable_variable["variableName"], self.spec
+            )
+
+            cache_utils.update_cache(cacheable_variable, updated_value)
+
+    def supports_direct_transfer(self) -> bool:
+        """Return False, as a direct transfer is not supported."""
+        return False
+
+    def list_files(
+        self,
+        directory: str | None = None,  # noqa: ARG002
+        file_pattern: str | None = None,  # noqa: ARG002
+    ) -> dict:
+        """Return list of files that match the source definition.
+
+        Args:
+            directory (str, optional): The directory to search in. Defaults to None.
+            file_pattern (str, optional): The file pattern to search for. Defaults to
+            None.
+
+        Returns:
+            dict: A dict of files that match the source definition.
+        """
+        return {}
+
+    def pull_files_to_worker(
+        self, files: list[str], local_staging_directory: str  # noqa: ARG002
+    ) -> int:
+        """Pull files to the worker.
+
+        This is not applicable for a local transfer, since the files are local already.
+        The files will not be transferred as they'll just fill up the worker's disk for
+        no reason.
+
+        All args are not used because this function literally does nothing.
+
+        Args:
+            files (list): A list of files to download.
+            local_staging_directory (str): The local staging directory to move the files
+            into.
+
+        Returns:
+            int: Always returns 0
+        """
+        return 0
+
+    def push_files_from_worker(
+        self, local_staging_directory: str, file_list: dict | None = None
+    ) -> int:
+        """Not implemented for this handler."""
+        raise NotImplementedError
+
+    def transfer_files(self, files: list[str]) -> None:
+        """Not implemented for this handler."""
+        raise NotImplementedError
+
+    def pull_files(self, files: list[str]) -> None:
+        """Not implemented for this handler."""
+        raise NotImplementedError
+
+    def move_files_to_final_location(self, files: list[str]) -> None:
+        """Not implemented for this handler."""
+        raise NotImplementedError
+
+    def handle_post_copy_action(self, files: list[str]) -> int:  # noqa: ARG002
+        """Handle the post copy action specified in the config.
+
+        Args:
+            files (list[str]): A list of files that need to be handled.
+
+        Returns:
+            int: 0 if successful, 1 if not.
+        """
+        return 0
+
+    def create_flag_files(self) -> int:
+        """Create the flag files on the remote host.
+
+        Raises:
+            NotImplementedError: This method is not implemented for this handler.
+        """
+        raise NotImplementedError

--- a/src/opentaskpy/remotehandlers/remotehandler.py
+++ b/src/opentaskpy/remotehandlers/remotehandler.py
@@ -131,8 +131,40 @@ class RemoteTransferHandler(RemoteHandler):
             int: The result of the transfer. 0 for success, 1 for failure.
         """
 
+    def handle_cacheable_variables(self) -> None:
+        """Handle cacheable variables.
+
+        This method is called whenever appropriate in the flow of the remote handler. It
+        should handle any cacheable variables that need to be updated by calling the
+        appropriate caching plugin.
+        """
+
     def tidy(self) -> None:
         """Tidy up after the transfer, if necessary. Otherwise do nothing."""
+
+    def obtain_variable_from_spec(self, variable_name: str, spec: dict) -> str:
+        """Using the spec, obtain the current value of the variable.
+
+        Args:
+            variable_name (str): The name of the variable to obtain.
+            spec (dict): The spec to search for the variable.
+
+        Returns:
+            str: The value of the variable.
+        """
+        # Look in the dictionary for the variable based on the variable name
+        # e.g. if the variable name is x.y obtain the value of spec['x']['y']
+        # We also need to handle arrays e.g. x.y[0] should return spec['x']['y'][0]
+
+        # Not ideal, but don't want this loading all the time for no reason
+        from ast import literal_eval  # pylint: disable=import-outside-toplevel
+
+        from omegaconf import OmegaConf  # pylint: disable=import-outside-toplevel
+
+        # pylint: disable-next=unused-variable
+        dotted_dict = OmegaConf.create(spec)  # noqa: F841
+
+        return str(literal_eval(f"dotted_dict.{variable_name}"))
 
 
 class RemoteExecutionHandler(RemoteHandler):

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -43,6 +43,9 @@ DEFAULT_PROTOCOL_MAP = {
     "local": DefaultProtocolCharacteristics(
         "opentaskpy.remotehandlers.local", "LocalTransfer"
     ),
+    "dummy": DefaultProtocolCharacteristics(
+        "opentaskpy.remotehandlers.dummy", "DummyTransfer"
+    ),
 }
 DEFAULT_STAGING_DIR_BASE = "/tmp"  # nosec B108
 

--- a/tests/test_cacheable_variable_file.py
+++ b/tests/test_cacheable_variable_file.py
@@ -1,0 +1,42 @@
+# pylint: skip-file
+# ruff: noqa
+
+import pytest
+
+from opentaskpy.config.variablecaching import file
+from opentaskpy.exceptions import CachingPluginError
+
+
+def test_cacheable_variable_file(tmpdir):
+
+    spec = {"task_id": "1234", "x": {"y": "value"}}
+
+    kwargs = {"file": f"{tmpdir}/cacheable_variable.txt", "value": "newvalue"}
+
+    file.run(**kwargs)
+
+    # Check the new file has content of "newvalue"
+    with open(f"{tmpdir}/cacheable_variable.txt", "r") as f:
+        assert f.read() == "newvalue"
+
+
+def test_cacheable_variable_file_invalid(tmpdir):
+
+    spec = {"task_id": "1234", "x": {"y": "value"}}
+
+    kwargs = {"file": f"/NONEXISTENT/NONEXISTENT", "value": "newvalue"}
+
+    # Should throw a FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        file.run(**kwargs)
+
+
+def test_cachable_variable_file_invalid_args():
+    with pytest.raises(CachingPluginError):
+        file.run()
+
+    with pytest.raises(CachingPluginError):
+        file.run(file="/tmp/file.txt")
+
+    with pytest.raises(CachingPluginError):
+        file.run(value="newvalue")

--- a/tests/test_dummy_transfer_schema_validate.py
+++ b/tests/test_dummy_transfer_schema_validate.py
@@ -23,19 +23,20 @@ def test_dummy_with_cachable_variables(valid_source_definition):
     json_data = {
         "type": "transfer",
         "source": valid_source_definition,
-        "cacheableVariables": [
-            {
-                "variableName": "source.accessToken",
-                "cachingPlugin": "file",
-                "cacheArgs": {
-                    "file": "/tmp/cacheable_variable.txt",
-                },
-            }
-        ],
     }
+
+    json_data["source"]["cacheableVariables"] = [
+        {
+            "variableName": "accessToken",
+            "cachingPlugin": "file",
+            "cacheArgs": {
+                "file": "/tmp/cacheable_variable.txt",
+            },
+        }
+    ]
 
     assert validate_transfer_json(json_data)
 
     # Remove the cacheArgs and validate the validation fails
-    del json_data["cacheableVariables"][0]["cacheArgs"]
+    del json_data["source"]["cacheableVariables"][0]["cacheArgs"]
     assert not validate_transfer_json(json_data)

--- a/tests/test_dummy_transfer_schema_validate.py
+++ b/tests/test_dummy_transfer_schema_validate.py
@@ -1,0 +1,41 @@
+# pylint: skip-file
+import pytest
+
+from opentaskpy.config.schemas import validate_transfer_json
+
+
+@pytest.fixture(scope="function")
+def valid_source_definition():
+    return {
+        "accessToken": "1234",
+        "protocol": {"name": "dummy"},
+    }
+
+
+def test_dummy_basic(valid_source_definition):
+    json_data = {"type": "transfer", "source": valid_source_definition}
+
+    assert validate_transfer_json(json_data)
+
+
+# Test dummy again but with cachableVariables defined too
+def test_dummy_with_cachable_variables(valid_source_definition):
+    json_data = {
+        "type": "transfer",
+        "source": valid_source_definition,
+        "cacheableVariables": [
+            {
+                "variableName": "source.accessToken",
+                "cachingPlugin": "file",
+                "cacheArgs": {
+                    "file": "/tmp/cacheable_variable.txt",
+                },
+            }
+        ],
+    }
+
+    assert validate_transfer_json(json_data)
+
+    # Remove the cacheArgs and validate the validation fails
+    del json_data["cacheableVariables"][0]["cacheArgs"]
+    assert not validate_transfer_json(json_data)

--- a/tests/test_remotehandler.py
+++ b/tests/test_remotehandler.py
@@ -1,0 +1,29 @@
+# pylint: skip-file
+# ruff: noqa
+
+import pytest
+
+from opentaskpy.remotehandlers.ssh import SSHTransfer
+
+
+def test_cacheable_variable_dotted_notation():
+
+    spec = {"task_id": "1234", "x": {"y": "value"}}
+    rh = SSHTransfer(spec)
+
+    assert rh.obtain_variable_from_spec("x.y", spec) == "value"
+
+
+def test_cacheable_variable_dotted_notation_array():
+
+    spec = {
+        "task_id": "1234",
+        "hostname": "172.16.0.11",
+        "directory": "/tmp/testFiles/src",
+        "fileRegex": ".*taskhandler.proxy\\.txt",
+        "invalidParam": [1, 2, 3, 4, 5],
+        "protocol": {"name": "ssh", "credentials": {"username": "application"}},
+    }
+    rh = SSHTransfer(spec)
+
+    assert rh.obtain_variable_from_spec("invalidParam[2]", spec) == "3"

--- a/tests/test_taskhandler_transfer_dummy.py
+++ b/tests/test_taskhandler_transfer_dummy.py
@@ -1,6 +1,7 @@
 # pylint: skip-file
 # ruff: noqa
 import os
+from copy import deepcopy
 
 import pytest
 
@@ -26,12 +27,15 @@ dummy_task_definition = {
 def test_dummy_transfer_cacheable_invalid_variable_name():
     from opentaskpy.remotehandlers.dummy import DummyTransfer
 
-    dummy_task_definition["cacheableVariables"][0][
+    # Copy the task definition
+    dummy_task_definition_copy = deepcopy(dummy_task_definition)
+
+    dummy_task_definition_copy["cacheableVariables"][0][
         "variableName"
     ] = "print('something_bad')"
 
     with pytest.raises(ValueError) as e:
-        DummyTransfer(dummy_task_definition)
+        DummyTransfer(dummy_task_definition_copy)
         # Check the message
     assert (
         "Variable name print('something_bad') is not a valid variable name."
@@ -44,11 +48,13 @@ def test_dummy_transfer(tmpdir):
     #  is written to the cache file
     from opentaskpy.remotehandlers.dummy import DummyTransfer
 
-    dummy_task_definition["cacheableVariables"][0]["cacheArgs"][
+    dummy_task_definition_copy = deepcopy(dummy_task_definition)
+
+    dummy_task_definition_copy["cacheableVariables"][0]["cacheArgs"][
         "file"
     ] = f"{tmpdir}/cacheable_variable.txt"
 
-    dummy_transfer = DummyTransfer(dummy_task_definition)
+    dummy_transfer = DummyTransfer(dummy_task_definition_copy)
 
     # Check the cache file exists on the filesystem
     assert os.path.exists(f"{tmpdir}/cacheable_variable.txt")

--- a/tests/test_taskhandler_transfer_dummy.py
+++ b/tests/test_taskhandler_transfer_dummy.py
@@ -23,6 +23,22 @@ dummy_task_definition = {
 }
 
 
+def test_dummy_transfer_cacheable_invalid_variable_name():
+    from opentaskpy.remotehandlers.dummy import DummyTransfer
+
+    dummy_task_definition["cacheableVariables"][0][
+        "variableName"
+    ] = "print('something_bad')"
+
+    with pytest.raises(ValueError) as e:
+        DummyTransfer(dummy_task_definition)
+        # Check the message
+    assert (
+        "Variable name print('something_bad') is not a valid variable name."
+        in e.value.args[0]
+    )
+
+
 def test_dummy_transfer(tmpdir):
     #  The key thing to test is that the access token
     #  is written to the cache file

--- a/tests/test_taskhandler_transfer_dummy.py
+++ b/tests/test_taskhandler_transfer_dummy.py
@@ -9,9 +9,9 @@ from opentaskpy.exceptions import FilesDoNotMeetConditionsError
 from opentaskpy.taskhandlers import transfer
 
 dummy_task_definition = {
-    "task_id": 1234,
     "type": "transfer",
     "source": {
+        "taskId": 123,
         "accessToken": "0",
         "protocol": {"name": "dummy"},
         "cacheableVariables": [
@@ -33,12 +33,12 @@ def test_dummy_transfer_cacheable_invalid_variable_name():
     # Copy the task definition
     dummy_task_definition_copy = deepcopy(dummy_task_definition)
 
-    dummy_task_definition_copy["cacheableVariables"][0][
+    dummy_task_definition_copy["source"]["cacheableVariables"][0][
         "variableName"
     ] = "print('something_bad')"
 
     with pytest.raises(ValueError) as e:
-        DummyTransfer(dummy_task_definition_copy)
+        DummyTransfer(dummy_task_definition_copy["source"])
         # Check the message
     assert (
         "Variable name print('something_bad') is not a valid variable name."

--- a/tests/test_taskhandler_transfer_dummy.py
+++ b/tests/test_taskhandler_transfer_dummy.py
@@ -1,0 +1,45 @@
+# pylint: skip-file
+# ruff: noqa
+import os
+
+import pytest
+
+dummy_task_definition = {
+    "task_id": 1234,
+    "type": "transfer",
+    "source": {
+        "accessToken": "0",
+        "protocol": {"name": "opentaskpy.remotehandlers.dummy"},
+    },
+    "cacheableVariables": [
+        {
+            "variableName": "source.accessToken",
+            "cachingPlugin": "file",
+            "cacheArgs": {
+                "file": "/tmp/cacheable_variable.txt",
+            },
+        }
+    ],
+}
+
+
+def test_dummy_transfer(tmpdir):
+    #  The key thing to test is that the access token
+    #  is written to the cache file
+    from opentaskpy.remotehandlers.dummy import DummyTransfer
+
+    dummy_task_definition["cacheableVariables"][0]["cacheArgs"][
+        "file"
+    ] = f"{tmpdir}/cacheable_variable.txt"
+
+    dummy_transfer = DummyTransfer(dummy_task_definition)
+
+    # Check the cache file exists on the filesystem
+    assert os.path.exists(f"{tmpdir}/cacheable_variable.txt")
+
+    # Check the cache file has a random number in it now that's not the original
+
+    with open(f"{tmpdir}/cacheable_variable.txt", "r") as f:
+        contents = f.read()
+        assert contents != "0"
+        assert contents.isdigit()


### PR DESCRIPTION
This pull request adds support for cacheable variables. It includes the following changes:

- Added new cacheable variables

- Updated dependencies to include "omegaconf >= 2.3.0"

- Added a new JSON schema for a dummy source protocol

- Added a new exception class for caching plugin errors

- Updated VS Code settings to include write permissions for specific repositories in Codespaces

- Added new test cases for cacheable variables and caching plugins

- Added utility functions for updating the cache with new values

- Added a new JSON schema for cacheable variables

- Added new test cases for validating transfer JSON with dummy source and cacheable variables

These changes enable the caching of specific variables and provide flexibility for using different caching plugins.