### PR TITLE
Fix/replace stray escaped chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.25.0
+
+- Remove stray `\\n` characters from private and public keys when doing encryption/decryption, and replace with proper newlines
+
 # v24.23.0
 
 - Added new `cacheableVariables` option for transfers. This allows you to specify a list of variables that should be cached and written back to somewhere (depending on the `cachingPlugin` referenced). This is useful for dynamically updated variables that need to be stored centrally. For more detail see the `README.md`ß

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.23.0"
+version = "v24.25.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.23.0"
+current_version = "v24.25.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -770,6 +770,9 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         # Set up gnupg
         gpg = gnupg.GPG(gnupghome=f"{tmpdir}/.gnupg")
 
+        # Remove any escaped newline characters from the key
+        public_key = public_key.replace("\\n", "\n")
+
         # Load the public key
         import_result = gpg.import_keys(public_key)
 
@@ -846,6 +849,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
         # Set up gnupg
         gpg = gnupg.GPG(gnupghome=f"{tmpdir}/.gnupg")
+
+        private_key = private_key.replace("\\n", "\n")
 
         # Load the private key
         import_result = gpg.import_keys(private_key)


### PR DESCRIPTION
Replace any \\n that appears in a public/private key with a proper \n character when encrypting/decrypting files