### PR TITLE
fix: Lazy loading breaks `noop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.37.0
+
+- Fix issue where new lazy loading code conflicts with `NOOP` mode, where it was trying to resolve variables regardless
+
 # v24.36.2
 
 - Add OTF_PARAMIKO_ULTRA_DEBUG environment variable to enable the hidden `ultra_debug` option for Paramiko (SFTP only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.36.2"
+version = "v24.37.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.36.2"
+current_version = "v24.37.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
Prevent new lazy loading logic to load in unresolved variables from conflicting with the no op functionality where some variables are intentionally not resolved.