### PR TITLE
Moved counter for checking handler classes to outside the condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.42.0
+
+- Fix issue where different protocols where not being detected properly, and proxy had to be explicitly defined when it was unnecessary
+
 # No release
 
 - Bump `black` to 24.10.0

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -403,7 +403,6 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 ):
                     different_protocols = True
                     any_different_protocols = True
-                    i += 1
 
                 # If there are differences, download the file locally first
                 # so it's ready to upload to multiple destinations at once
@@ -431,6 +430,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                             "Pull to worker from remote source errored",
                             exception=exceptions.RemoteTransferError,
                         )
+                i += 1
 
             # Before doing any file movements, check to see if file decryption or encryption is
             # required on the source or destination. For any unsupported transferTypes we need to fail here first


### PR DESCRIPTION
This pull request includes a bug fix and a minor code adjustment in the `src/opentaskpy/taskhandlers/transfer.py` file. The most important changes are listed below:

Bug Fix:

* `src/opentaskpy/taskhandlers/transfer.py`: Moved the increment of the variable `i` to ensure it is executed in the appropriate control flow, preventing potential issues in the loop logic.

Fixes #102 