### PR TITLE
Feat: Configure SFTP timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.44.2
+
+- Make SFTP timeout configurable within protocol definition
+
 # v24.44.1
 
 - Fix batch logic to ensure that all tasks run before exiting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.44.1"
+version = "v24.44.2"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.44.1"
+current_version = "v24.44.2"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/sftp_destination/protocol.json
@@ -16,6 +16,9 @@
     "knownHostsFile": {
       "type": "string"
     },
+    "timeout": {
+      "type": "integer"
+    },
     "supportsPosixRename": {
       "type": "boolean",
       "default": true

--- a/src/opentaskpy/config/schemas/transfer/sftp_source/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/sftp_source/protocol.json
@@ -16,6 +16,9 @@
     "knownHostsFile": {
       "type": "string"
     },
+    "timeout": {
+      "type": "integer"
+    },
     "supportsPosixRename": {
       "type": "boolean",
       "default": true

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -79,7 +79,7 @@ class SFTPTransfer(RemoteTransferHandler):
             "hostname": hostname,
             "port": (self.spec["protocol"].get("port", 22)),
             "username": self.spec["protocol"]["credentials"]["username"],
-            "timeout": 3,
+            "timeout": (self.spec["protocol"].get("timeout", 3)),
             "allow_agent": False,
         }
 

--- a/tests/test_taskhandler_transfer_sftp.py
+++ b/tests/test_taskhandler_transfer_sftp.py
@@ -25,13 +25,21 @@ sftp_task_definition = {
         "hostname": "172.16.0.21",
         "directory": "/home/application/testFiles/src",
         "fileRegex": ".*taskhandler.*\\.txt",
-        "protocol": {"name": "sftp", "credentials": {"username": "application"}},
+        "protocol": {
+            "name": "sftp",
+            "credentials": {"username": "application"},
+            "timeout": 20,
+        },
     },
     "destination": [
         {
             "hostname": "172.16.0.22",
             "directory": "/home/application/testFiles/dest",
-            "protocol": {"name": "sftp", "credentials": {"username": "application"}},
+            "protocol": {
+                "name": "sftp",
+                "credentials": {"username": "application"},
+                "timeout": 20,
+            },
         },
     ],
 }


### PR DESCRIPTION
### SFTP Timeout Configuration:

* Added `timeout` property to the SFTP protocol schema in `protocol.json` files for both SFTP source and destination. [[1]](diffhunk://#diff-bddd03045bdb25ac06732e916690af663f921c46b69cad95168ee64163380983R19-R21) [[2]](diffhunk://#diff-068f423f8daf1ac57df1ec17144dcafb43d97f2a7c57e679931f76094e83d27aR19-R21)
* Updated the `connect` method in `sftp.py` to use the configurable `timeout` value from the protocol definition, defaulting to 3 seconds if not specified.
* Modified the SFTP transfer test cases to include the `timeout` property in the protocol definition.