### PR TITLE
Fix: Stale batches on dependency failures

### DIFF
--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -19,7 +19,7 @@ jobs:
   daily-test:
     name: Daily Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.5.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,7 +301,7 @@ jobs:
     name: test
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: prepare-base
     steps:
       - name: Check out code from GitHub

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
       "program": "${file}",
       "preLaunchTask": "Build Test containers",
       "console": "integratedTerminal",
-      "args": ["-t", "scp-basic", "-v", "2", "-c", "test/cfg"],
+      "args": ["-t", "test-batch", "-v", "2", "-c", "test/cfg"],
       "justMyCode": false
     },
     {
@@ -32,6 +32,35 @@
       "console": "integratedTerminal",
       "args": ["-t", "scp-basic", "-c", "test/cfg", "-v3"],
       "justMyCode": false
+    },
+    {
+      "name": "Python: Transfer - Batch - Local Dependencies",
+      "type": "debugpy",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": ["-t", "batch-dependencies-complex", "-c", "test/cfg", "-v3"],
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Transfer - Batch - Local Dependencies - Fail",
+      "type": "debugpy",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": [
+        "-t",
+        "batch-dependencies-complex-fail",
+        "-c",
+        "test/cfg",
+        "-v3"
+      ],
+      "justMyCode": false,
+      "env": {
+        "OTF_NO_LOG": "1"
+      }
     },
     {
       "name": "Python: Transfer - SFTP Basic",
@@ -83,7 +112,7 @@
       "preLaunchTask": "Build Test containers",
       "program": "src/opentaskpy/cli/task_run.py",
       "console": "integratedTerminal",
-      "args": ["-t", "batch-15-sftp", "-c", "test/cfg", "-v3"],
+      "args": ["-t", "test-batch", "-c", "test/cfg", "-v3"],
       "justMyCode": false
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v24.47.0
+
+- Refactored dependency checker method to support Running/Failed state
+
 # v24.46.0
 
 - Added support for PostCopyAction dir auto-creation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.46.0"
+version = "v24.47.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.46.0"
+current_version = "v24.47.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -202,10 +202,10 @@ class Batch(TaskHandler):
         Args:
             order_id (int): Order id of task in batch
             batch_task (dict): Batch task dictionary
-            check_only_failed (bool): Check for completed tasks if false (default), else failed if True
+            check_only_failed (bool): Check for completed tasks if false (default), else failed ones
 
         Returns:
-            bool: True if all batch task dependencies have completed (or failed if check_failed), False otherwise .
+            bool: True if all batch task dependencies are not in COMPLETED, FAILED or TIMED_OUT state (therefore still Running), False otherwise .
         """
         for dependency in batch_task["batch_task_spec"]["dependencies"]:
             if (
@@ -224,6 +224,9 @@ class Batch(TaskHandler):
                 self.task_order_tree[dependency]["status"] in ["FAILED", "TIMED_OUT"]
             ) and check_only_failed:
                 return False
+        self.logger.info(
+            f"All dependencies for task {order_id} ({batch_task['task_id']}) have completed"
+        )
         return True
 
     def run(self, kill_event: threading.Event | None = None) -> bool:  # noqa: C901
@@ -364,8 +367,6 @@ class Batch(TaskHandler):
                     batch_task["result"] = False
                     logged = True
 
-                batch_task["logged_status"] = logged
-                batch_task["logged_status"] = logged
                 batch_task["logged_status"] = logged
 
             # Check if there are any tasks that are still in RUNNING state, if not then we are done

--- a/test/cfg/batch/batch-dependencies-complex-fail.json
+++ b/test/cfg/batch/batch-dependencies-complex-fail.json
@@ -1,0 +1,45 @@
+{
+  "type": "batch",
+  "tasks": [
+    {
+      "order_id": 1,
+      "task_id": "sleep-5-local",
+      "timeout": 60
+    },
+    {
+      "order_id": 2,
+      "task_id": "exit-1-local",
+      "timeout": 60,
+      "dependencies": [1]
+    },
+    {
+      "order_id": 3,
+      "task_id": "sleep-5-local",
+      "timeout": 60,
+      "dependencies": [2]
+    },
+    {
+      "order_id": 4,
+      "task_id": "sleep-5-local",
+      "timeout": 60,
+      "dependencies": [3]
+    },
+    {
+      "order_id": 5,
+      "task_id": "sleep-5-local",
+      "timeout": 60
+    },
+    {
+      "order_id": 6,
+      "task_id": "sleep-7-local",
+      "timeout": 60,
+      "dependencies": [5]
+    },
+    {
+      "order_id": 7,
+      "task_id": "sleep-5-local",
+      "timeout": 60,
+      "dependencies": [6]
+    }
+  ]
+}

--- a/test/cfg/batch/batch-dependencies-complex.json
+++ b/test/cfg/batch/batch-dependencies-complex.json
@@ -1,0 +1,39 @@
+{
+  "type": "batch",
+  "tasks": [
+    {
+      "order_id": 1,
+      "task_id": "sleep-5-local",
+      "timeout": 60
+    },
+    {
+      "order_id": 2,
+      "task_id": "sleep-7-local",
+      "timeout": 60,
+      "dependencies": [1]
+    },
+    {
+      "order_id": 3,
+      "task_id": "sleep-5-local",
+      "timeout": 60,
+      "dependencies": [2]
+    },
+    {
+      "order_id": 4,
+      "task_id": "sleep-5-local",
+      "timeout": 60
+    },
+    {
+      "order_id": 5,
+      "task_id": "sleep-7-local",
+      "timeout": 60,
+      "dependencies": [4]
+    },
+    {
+      "order_id": 6,
+      "task_id": "sleep-5-local",
+      "timeout": 60,
+      "dependencies": [5]
+    }
+  ]
+}

--- a/test/cfg/batch/test-batch.json
+++ b/test/cfg/batch/test-batch.json
@@ -1,0 +1,21 @@
+{
+  "type": "batch",
+  "tasks": [
+    {
+      "order_id": 17,
+      "task_id": "sleep-5",
+      "timeout": 7200
+    },
+    {
+      "order_id": 19,
+      "task_id": "sleep-5",
+      "timeout": 7200
+    },
+    {
+      "order_id": 20,
+      "task_id": "local-basic",
+      "timeout": 900,
+      "dependencies": [19]
+    }
+  ]
+}

--- a/test/cfg/executions/exit-1-local.json
+++ b/test/cfg/executions/exit-1-local.json
@@ -1,0 +1,8 @@
+{
+  "type": "execution",
+  "directory": "/tmp",
+  "command": "exit 1",
+  "protocol": {
+    "name": "local"
+  }
+}

--- a/test/cfg/executions/sleep-5-local.json
+++ b/test/cfg/executions/sleep-5-local.json
@@ -1,0 +1,8 @@
+{
+  "type": "execution",
+  "directory": "/tmp",
+  "command": "sleep 5",
+  "protocol": {
+    "name": "local"
+  }
+}

--- a/test/cfg/executions/sleep-7-local.json
+++ b/test/cfg/executions/sleep-7-local.json
@@ -1,0 +1,8 @@
+{
+  "type": "execution",
+  "directory": "/tmp",
+  "command": "sleep 7",
+  "protocol": {
+    "name": "local"
+  }
+}

--- a/test/cfg/transfers/filewatch-5-error-sftp.json
+++ b/test/cfg/transfers/filewatch-5-error-sftp.json
@@ -1,0 +1,17 @@
+{
+  "type": "transfer",
+  "source": {
+    "hostname": "172.16.0.21",
+    "directory": "/tmp/testFiles/src",
+    "fileRegex": "non-existent-file-005-1234\\.txt",
+    "fileWatch": {
+      "timeout": 5
+    },
+    "protocol": {
+      "name": "sftp",
+      "credentials": {
+        "username": "{{ SSH_USERNAME }}"
+      }
+    }
+  }
+}

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -216,8 +216,12 @@ fail_batch_definition_dependencies = {
             "order_id": 2,
             "task_id": "filewatch-5-error-sftp",
         },
-        {"order_id": 3, "task_id": "filewatch-5-error-sftp", "dependencies": [1, 2]},
-        {"order_id": 4, "task_id": "filewatch-5-error-sftp", "dependencies": [3]},
+        {
+            "order_id": 3,
+            "task_id": "sleep-5",
+        },
+        {"order_id": 4, "task_id": "filewatch-5-error-sftp", "dependencies": [1, 2]},
+        {"order_id": 5, "task_id": "filewatch-5-error-sftp", "dependencies": [3]},
     ],
 }
 

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -210,19 +210,19 @@ fail_batch_definition_dependencies = {
     "tasks": [
         {
             "order_id": 1,
-            "task_id": "sleep-5",
+            "task_id": "sleep-5-local",
         },
         {
             "order_id": 2,
-            "task_id": "filewatch-5-error-sftp",
+            "task_id": "exit-1-local",
         },
         {
             "order_id": 3,
-            "task_id": "sleep-5",
+            "task_id": "sleep-5-local",
         },
-        {"order_id": 4, "task_id": "filewatch-5-error-sftp", "dependencies": [1, 2]},
-        {"order_id": 5, "task_id": "filewatch-5-error-sftp", "dependencies": [3]},
-        {"order_id": 6, "task_id": "filewatch-5-error-sftp", "dependencies": [4]},
+        {"order_id": 4, "task_id": "exit-1-local", "dependencies": [1, 2]},
+        {"order_id": 5, "task_id": "exit-1-local", "dependencies": [3]},
+        {"order_id": 6, "task_id": "exit-1-local", "dependencies": [4]},
     ],
 }
 
@@ -592,9 +592,7 @@ def test_batch_continue_on_failure(setup_ssh_keys, env_vars, root_dir, clear_log
     assert os.path.exists(log_file_name_scp_task.replace("_running", ""))
 
 
-def test_batch_task_id_failed_dependencies(
-    root_dir, setup_ssh_keys, env_vars, clear_logs
-):
+def test_batch_task_id_failed_dependencies(root_dir, env_vars, clear_logs):
 
     # We need a config loader object, so that the batch class can load in the configs for
     # the sub tasks

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -205,6 +205,18 @@ fail_batch_definition = {
     ],
 }
 
+fail_batch_definition_dependencies = {
+    "type": "batch",
+    "tasks": [
+        {
+            "order_id": 1,
+            "task_id": "filewatch-5-error-sftp",
+        },
+        {"order_id": 2, "task_id": "filewatch-5-error-sftp", "dependencies": [1]},
+        {"order_id": 3, "task_id": "filewatch-5-error-sftp", "dependencies": [2]},
+    ],
+}
+
 # Create a variable with a random number
 RANDOM = random.randint(10000, 99999)
 
@@ -569,3 +581,18 @@ def test_batch_continue_on_failure(setup_ssh_keys, env_vars, root_dir, clear_log
 
     # The successful task should have a successful
     assert os.path.exists(log_file_name_scp_task.replace("_running", ""))
+
+
+def test_batch_task_id_failed_dependencies(
+    root_dir, setup_ssh_keys, env_vars, clear_logs
+):
+
+    # We need a config loader object, so that the batch class can load in the configs for
+    # the sub tasks
+    config_loader = ConfigLoader("test/cfg")
+    # Expect a FileNotFoundError as the task_id is non-existent
+    batchObj = batch.Batch(
+        None, f"fail-{RANDOM}", fail_batch_definition_dependencies, config_loader
+    )
+
+    assert not batchObj.run()

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -222,6 +222,7 @@ fail_batch_definition_dependencies = {
         },
         {"order_id": 4, "task_id": "filewatch-5-error-sftp", "dependencies": [1, 2]},
         {"order_id": 5, "task_id": "filewatch-5-error-sftp", "dependencies": [3]},
+        {"order_id": 6, "task_id": "filewatch-5-error-sftp", "dependencies": [4]},
     ],
 }
 

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -210,10 +210,14 @@ fail_batch_definition_dependencies = {
     "tasks": [
         {
             "order_id": 1,
+            "task_id": "sleep-5",
+        },
+        {
+            "order_id": 2,
             "task_id": "filewatch-5-error-sftp",
         },
-        {"order_id": 2, "task_id": "filewatch-5-error-sftp", "dependencies": [1]},
-        {"order_id": 3, "task_id": "filewatch-5-error-sftp", "dependencies": [2]},
+        {"order_id": 3, "task_id": "filewatch-5-error-sftp", "dependencies": [1, 2]},
+        {"order_id": 4, "task_id": "filewatch-5-error-sftp", "dependencies": [3]},
     ],
 }
 


### PR DESCRIPTION
In some cases, batches go stale.
Looks like it is due to:
- Failed dependencies
- Timed out dependencies (when batch times out before task)

This PR tries to fix it