### PR TITLE
Fix: Batch Task executions being skipped

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -262,6 +262,25 @@
       "justMyCode": false
     },
     {
+      "name": "Python: Batch - Parallel - Dependencies",
+      "type": "debugpy",
+      "request": "launch",
+      "preLaunchTask": "Build Test containers",
+      "program": "src/opentaskpy/cli/task_run.py",
+      "console": "integratedTerminal",
+      "args": [
+        "-t",
+        "batch-parallel-dependencies",
+        "-v",
+        "1",
+        "-c",
+        "test/cfg",
+        "-r",
+        "job-par-dep"
+      ],
+      "justMyCode": false
+    },
+    {
       "name": "Python: Batch - Continue on fail",
       "type": "debugpy",
       "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# v24.51.0
+
+- Fixing dependency checker in batches
+- Including Runnable task checker before breaking execution loop
+- Improved code readability
+
 # v24.47.1
 
 - Add missing try/catch to decryption code when trying to delete gnupg directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v24.47.1"
+version = "v24.51.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.47.1"
+current_version = "v24.51.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/test/cfg/batch/batch-parallel-dependencies.json
+++ b/test/cfg/batch/batch-parallel-dependencies.json
@@ -1,0 +1,115 @@
+{
+  "type": "batch",
+  "tasks": [
+    {
+      "order_id": 1,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 2,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [1]
+    },
+    {
+      "order_id": 3,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 4,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [3]
+    },
+    {
+      "order_id": 5,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 6,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [5]
+    },
+    {
+      "order_id": 7,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 8,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [7]
+    },
+    {
+      "order_id": 9,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 10,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [9]
+    },
+    {
+      "order_id": 11,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 12,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [11]
+    },
+    {
+      "order_id": 13,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 14,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [13]
+    },
+    {
+      "order_id": 15,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 16,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [15]
+    },
+    {
+      "order_id": 17,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 18,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [17]
+    },
+    {
+      "order_id": 19,
+      "task_id": "sleep-7-local",
+      "timeout": 7200
+    },
+    {
+      "order_id": 20,
+      "task_id": "sleep-5",
+      "timeout": 900,
+      "dependencies": [19]
+    }
+  ]
+}

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -603,3 +603,14 @@ def test_batch_task_id_failed_dependencies(root_dir, env_vars, clear_logs):
     )
 
     assert not batchObj.run()
+
+
+def test_batch_check_all_dependencies_fail():
+    batch_task = {
+        "task_id": "test-batch-deps-checker",
+        "batch_task_spec": {"order_id": 1, "task_id": "sleep-5-local"},
+        "task": {"type": "execution", "directory": "/tmp", "command": "sleep 5"},
+    }
+    assert not batch.Batch.check_all_dependency_statuses(
+        None, batch_task, ["COMPLETED"]
+    )


### PR DESCRIPTION
This PR resolves batch tasks being skipped despite all dependencies completing.

The cause was a delay between checking for running tasks and the Execution task not being in Running state yet.

