### PR TITLE
Feat/email destination changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#v25.3.1
+
+- Adjust email_destination TaskHandler to allow use of TLS/credentials to be optional, and set default port to 587
+- Adjust email_destination protocol schema to ensure that smtp_server and sender are set
+
 # v25.3.0
 
 - Add ignore_errors=True to problematic .gnupg removal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v25.3.0"
+version = "v25.3.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.3.0"
+current_version = "v25.3.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/schemas/transfer/email/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/email/protocol.json
@@ -10,10 +10,15 @@
     "smtp_port": {
       "type": "number",
       "minimum": 1,
-      "maximum": 65535
+      "maximum": 65535,
+      "default": 25
     },
     "smtp_server": {
       "type": "string"
+    },
+    "start_tls": {
+      "type": "boolean",
+      "default": true
     },
     "sender": {
       "type": "string",
@@ -33,6 +38,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["name"],
+  "required": ["name", "smtp_server", "sender"],
   "additionalProperties": false
 }

--- a/src/opentaskpy/config/schemas/transfer/email/protocol.json
+++ b/src/opentaskpy/config/schemas/transfer/email/protocol.json
@@ -10,15 +10,13 @@
     "smtp_port": {
       "type": "number",
       "minimum": 1,
-      "maximum": 65535,
-      "default": 25
+      "maximum": 65535
     },
     "smtp_server": {
       "type": "string"
     },
-    "start_tls": {
-      "type": "boolean",
-      "default": true
+    "use_tls": {
+      "type": "boolean"
     },
     "sender": {
       "type": "string",

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -139,7 +139,7 @@ class EmailTransfer(RemoteTransferHandler):
                     smtp.starttls()
 
                 # Authenticate (if credentials specified)
-                if self.protocol_vars["credentials"]:
+                if "credentials" in self.protocol_vars:
                     smtp.login(
                         self.protocol_vars["credentials"]["username"],
                         self.protocol_vars["credentials"]["password"],

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -125,13 +125,15 @@ class EmailTransfer(RemoteTransferHandler):
                 )
                 if self.logger.getEffectiveLevel() <= DEBUG:
                     smtp.set_debuglevel(1)
-                smtp.starttls()
+                if self.protocol_vars["start_tls"]:
+                    smtp.starttls()
 
-                # Authenticate
-                smtp.login(
-                    self.protocol_vars["credentials"]["username"],
-                    self.protocol_vars["credentials"]["password"],
-                )
+                # Authenticate (if credentials specified)
+                if self.protocol_vars["credentials"]:
+                    smtp.login(
+                        self.protocol_vars["credentials"]["username"],
+                        self.protocol_vars["credentials"]["password"],
+                    )
 
                 smtp.sendmail(
                     self.protocol_vars["sender"], email_address, msg.as_string()

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -116,16 +116,26 @@ class EmailTransfer(RemoteTransferHandler):
 
             msg["From"] = self.protocol_vars["sender"]
 
+            # Set connection port, default to 587
+            smtp_port = 587
+            if "smtp_port" in self.protocol_vars:
+                smtp_port = self.protocol_vars["smtp_port"]
+
+            # Determine whether to use startTLS on connection
+            use_tls = True
+            if "use_tls" in self.protocol_vars and not self.protocol_vars["use_tls"]:
+                use_tls = False
+
             # Send the email using a provided SMTP server
             try:
                 self.logger.debug(f"Sending email to {email_address}")
                 smtp = smtplib.SMTP(
                     self.protocol_vars["smtp_server"],
-                    port=self.protocol_vars["smtp_port"],
+                    port=smtp_port,
                 )
                 if self.logger.getEffectiveLevel() <= DEBUG:
                     smtp.set_debuglevel(1)
-                if self.protocol_vars["start_tls"]:
+                if use_tls:
                     smtp.starttls()
 
                 # Authenticate (if credentials specified)

--- a/tests/test_email_transfer_schema_validate.py
+++ b/tests/test_email_transfer_schema_validate.py
@@ -6,7 +6,11 @@ from opentaskpy.config.schemas import validate_transfer_json
 
 @pytest.fixture(scope="function")
 def valid_protocol_definition():
-    return {"name": "email"}
+    return {
+        "name": "email",
+        "smtp_server": "smtp.gmail.com",
+        "sender": "Test Sender <test@example.com>",
+    }
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_schema_validate.py
+++ b/tests/test_schema_validate.py
@@ -16,7 +16,11 @@ def valid_protocol_definition():
 
 @pytest.fixture(scope="function")
 def valid_protocol_definition_2():
-    return {"name": "email"}
+    return {
+        "name": "email",
+        "smtp_server": "smtp.gmail.com",
+        "sender": "Test Sender <test@example.com>",
+    }
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
- Adjust email_destination TaskHandler to allow use of TLS/credentials to be optional, and set default port to 587
- Adjust email_destination protocol schema to ensure that smtp_server and sender are set