### PR TITLE
fix: Email body

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,10 +63,10 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
-        language: python
+        entry: "python"
+        language: system
         types: [python]
-        args: ["--version", "--config-file", "mypy.ini"]
+        args: ["-m", "mypy", "--config-file", "mypy.ini"]
         require_serial: true
         files: ^src/opentaskpy/.+\.py$
       - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         entry: mypy
         language: python
         types: [python]
-        args: ["--config-file", "mypy.ini"]
+        args: ["--version", "--config-file", "mypy.ini"]
         require_serial: true
         files: ^src/opentaskpy/.+\.py$
       - id: pylint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# v25.16.0
+
+- Fix schema for email destination task handler to include missing `message` attribute
+- Remove requirement for `accessToken` in dummy handler
+- Prevent `transfer.py` throwing an error when `dummy` protocol is used as the source and no files are returned
+- Add test to test email destination task handler with a custom email body
+
 # v25.15.0
 
 - Added new devcontainer for working with the OTF Addons in a single dev environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v25.15.0"
+version = "v25.16.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.15.0"
+current_version = "v25.16.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/schemas/transfer/dummy_source.json
+++ b/src/opentaskpy/config/schemas/transfer/dummy_source.json
@@ -11,9 +11,11 @@
     },
     "cacheableVariables": {
       "type": "array",
-      "items": { "$ref": "http://localhost/cacheable_variables.json" }
+      "items": {
+        "$ref": "http://localhost/cacheable_variables.json"
+      }
     }
   },
   "additionalProperties": false,
-  "required": ["accessToken", "protocol"]
+  "required": ["protocol"]
 }

--- a/src/opentaskpy/config/schemas/transfer/email_destination.json
+++ b/src/opentaskpy/config/schemas/transfer/email_destination.json
@@ -13,6 +13,9 @@
     "subject": {
       "type": "string"
     },
+    "message": {
+      "type": "string"
+    },
     "encryption": {
       "$ref": "http://localhost/transfer/encryption.json"
     },

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -116,6 +116,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         # Remove local staging directory if it exists (and this isn't a local transfer)
         if (
             path.exists(self.local_staging_dir)
+            and self.source_file_spec["protocol"]["name"] != "dummy"
             and self.local_staging_dir != self.source_file_spec["directory"]
         ):
             self.logger.info(

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -363,7 +363,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         if "conditionals" in self.source_file_spec and remote_files:
             remote_files = self.check_conditionals(remote_files)
 
-        if not remote_files:
+        if not remote_files and self.source_file_spec["protocol"]["name"] != "dummy":
             if "error" in self.source_file_spec and not self.source_file_spec["error"]:
                 return self.return_result(
                     0,

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -637,6 +637,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
             if (
                 different_protocols
+                and self.source_file_spec["protocol"]["name"] != "dummy"
                 and self.local_staging_dir != self.source_file_spec["directory"]
             ):
                 self.logger.debug("Removing local staging directory")

--- a/tests/test_taskhandler_transfer_dummy.py
+++ b/tests/test_taskhandler_transfer_dummy.py
@@ -60,8 +60,8 @@ def test_dummy_transfer(tmpdir):
     dummy_transfer_obj = transfer.Transfer(
         None, "dummy-transfer", dummy_task_definition_copy
     )
-    with pytest.raises(FilesDoNotMeetConditionsError) as e:
-        dummy_transfer_obj.run()
+
+    dummy_transfer_obj.run()
 
     # Check the cache file exists on the filesystem
     assert os.path.exists(f"{tmpdir}/cacheable_variable.txt")


### PR DESCRIPTION
This pull request introduces several updates and fixes across the codebase, including changes to configuration files, schema definitions, task handler logic, and test cases. The most significant changes involve adjustments to the email destination and dummy source task handlers, as well as improvements to testing coverage. Below is a breakdown of the key changes:

### Configuration and Pre-commit Hook Updates:
* Updated the `mypy` pre-commit hook in `.pre-commit-config.yaml` to use `python` as the entry and `system` as the language, and modified the `args` to invoke `mypy` as a module.

### Schema Adjustments:
* Added a new `message` attribute to the email destination schema in `email_destination.json` to support custom email body content.
* Removed the `accessToken` requirement from the dummy source schema in `dummy_source.json`, simplifying its usage.

### Task Handler Logic Fixes:
* Updated the `run` method in `transfer.py` to prevent errors when the `dummy` protocol is used as the source and no files are returned.

### Testing Enhancements:
* Added a new test case in `test_taskhandler_transfer_email.py` to validate the email destination task handler with a custom email body and a dummy source. This includes creating a task definition and verifying the transfer process. [[1]](diffhunk://#diff-1059a7554592755ed86cf2a6b0a4cb8d745f10a07a16dc48738b48e617ec444fR40-R61) [[2]](diffhunk://#diff-1059a7554592755ed86cf2a6b0a4cb8d745f10a07a16dc48738b48e617ec444fR174-R201)

### Documentation:
* Updated `CHANGELOG.md` to document the changes introduced in version `v25.16.0`, including schema fixes, dummy handler updates, error prevention in `transfer.py`, and new tests.