### PR TITLE
Minor adjustments to email file content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# v25.26.2
+# v25.32.0
 
 - Email destination task handler to load the email message once instead of once per recipient
 - Email message content file deletion now occurs only if all emails are sent successfully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v25.26.2
+
+- Email destination task handler to load the email message once instead of once per recipient
+- Email message content file deletion now occurs only if all emails are sent successfully
+
 # v25.26.1
 
 - Add the ability to add custom filters for Jinja2 templates under the `<config>/filters` directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v25.26.1"
+version = "v25.32.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.26.1"
+current_version = "v25.32.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -74,7 +74,7 @@ class EmailTransfer(RemoteTransferHandler):
         Returns:
             int: The result of the transfer.
         """
-       result = 0
+        result = 0
 
         if file_list:
             files = list(file_list.keys())
@@ -119,6 +119,7 @@ class EmailTransfer(RemoteTransferHandler):
             result = 1 
             return result
 
+       
         for email_address in self.spec["recipients"]:
             # Create an email message
             msg = MIMEMultipart()

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -116,10 +116,9 @@ class EmailTransfer(RemoteTransferHandler):
                 f"Failed to read message content file: {self.spec['messageContentFilename']}"
             )
             self.logger.error(ex)
-            result = 1 
+            result = 1
             return result
 
-       
         for email_address in self.spec["recipients"]:
             # Create an email message
             msg = MIMEMultipart()


### PR DESCRIPTION
1.  Email content file read once before iterating over recipients. Avoids reading the file multiple times. 
2. Delete content file only if all emails succeed. The delete operation now runs after all recipients have been processed. If any send fails, deletion is skipped. 