### PR TITLE
Feat: Email renaming

### DIFF
--- a/src/opentaskpy/config/schemas/transfer/email/rename.json
+++ b/src/opentaskpy/config/schemas/transfer/email/rename.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://localhost/transfer/email/rename.json",
+  "type": "object",
+  "properties": {
+    "pattern": {
+      "type": "string"
+    },
+    "sub": {
+      "type": "string"
+    }
+  },
+  "required": ["pattern", "sub"],
+  "additionalProperties": false
+}

--- a/src/opentaskpy/config/schemas/transfer/email_destination.json
+++ b/src/opentaskpy/config/schemas/transfer/email_destination.json
@@ -24,6 +24,9 @@
     "messageContentFilename": {
       "type": "string"
     },
+    "rename": {
+      "$ref": "http://localhost/transfer/email/rename.json"
+    },
     "deleteContentFileAfterTransfer": {
       "type": "boolean",
       "default": true


### PR DESCRIPTION
This pull request adds support for renaming email attachment files during transfer, based on configurable regex patterns. It includes schema changes, implementation in the email handler, and a new test to verify the feature.

**Feature: Email attachment file renaming**

* Added a new JSON schema `rename.json` to define the structure for file renaming rules, requiring a `pattern` and `sub` field.
* Updated `email_destination.json` schema to allow an optional `rename` property referencing the new `rename.json` schema.

**Implementation: Email handler**

* Modified `push_files_from_worker` in `email.py` to support renaming attachment filenames using regex substitution, without changing the actual files on disk. [[1]](diffhunk://#diff-7926a8de8e588f5d7ac6dfc12ccde62f53bce36dd8f150323400b89302f0b504R85-R102) [[2]](diffhunk://#diff-7926a8de8e588f5d7ac6dfc12ccde62f53bce36dd8f150323400b89302f0b504L127-R146)
* Imported the `re` module in `email.py` to enable regex-based renaming.

**Testing**

* Added a new test, `test_email_file_rename_transfer`, to verify that file renaming works as expected during email transfer.