### PR TITLE
feat: Added more verbose logging

### DIFF
--- a/src/opentaskpy/remotehandlers/local.py
+++ b/src/opentaskpy/remotehandlers/local.py
@@ -193,6 +193,10 @@ class LocalTransfer(RemoteTransferHandler):
                 shutil.copy(file, final_destination)
                 if mode:
                     os.chmod(final_destination, int(mode, base=8))
+
+                self.logger.info(
+                    f"[LOCALHOST] Copied file {file} to {final_destination}"
+                )
             except Exception as ex:  # pylint: disable=broad-exception-caught
                 self.logger.error(f"[LOCALHOST] Failed to move file: {ex}")
                 result = 1
@@ -227,6 +231,7 @@ class LocalTransfer(RemoteTransferHandler):
                 try:
                     self.logger.info(f"[LOCALHOST] Deleting file {file}")
                     os.remove(file)
+                    self.logger.info(f"[LOCALHOST] Deleted file {file}")
                 except OSError:
                     self.logger.error(
                         f"[LOCALHOST] Could not delete file {file} on source host"
@@ -272,6 +277,9 @@ class LocalTransfer(RemoteTransferHandler):
                             file,
                             f"{self.spec['postCopyAction']['destination']}/{file_name}",
                         )
+                        self.logger.info(
+                            f"[LOCALHOST] Renamed file {file} to {self.spec['postCopyAction']['destination']}/{file_name}"
+                        )
                     # If this is a rename, then we need to rename the file
                     if self.spec["postCopyAction"]["action"] == "rename":
                         # Determine the new file name
@@ -292,6 +300,9 @@ class LocalTransfer(RemoteTransferHandler):
                             f" {new_file_dir}/{new_file_name}"
                         )
                         os.rename(file, f"{new_file_dir}/{new_file_name}")
+                        self.logger.info(
+                            f"[LOCALHOST] Renamed file {file} to {new_file_dir}/{new_file_name}"
+                        )
                 except OSError as e:
                     self.logger.error(f"[LOCALHOST] Error: {e}")
                     self.logger.error(
@@ -319,6 +330,8 @@ class LocalTransfer(RemoteTransferHandler):
             # We cannot change ownership without using sudo, so we don't bother
             if "permissions" in self.spec:
                 os.chmod(filename, int(self.spec["permissions"], base=8))
+
+            self.logger.info(f"[LOCALHOST] Created flag file: {filename}")
 
         except OSError as e:
             self.logger.error(f"[LOCALHOST] Error: {e}")

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -275,14 +275,21 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         1, "KILLED DUE TO TIMEOUT FROM PARENT BATCH"
                     )
 
+                self.logger.info(
+                    f"Searching in {watch_directory} for files with"
+                    f" pattern {watch_file_pattern}",
+                )
                 remote_files = self.source_remote_handler.list_files(
                     directory=watch_directory, file_pattern=watch_file_pattern
                 )
                 if check_conditionals_during_filewatch and remote_files:
                     self.check_conditionals(remote_files)
-                # TODO: #5 Change all references to remote_files to expect a generator # pylint: disable=fixme
+
                 if remote_files:
-                    self.logger.info("Filewatch found remote file(s)")
+                    self.logger.info("Filewatch found remote file(s):")
+                    self.logger.info(
+                        f"Found {len(remote_files)} remote files: {remote_files}"
+                    )
                     break
 
                 remaining_seconds = ceil((start_time + timeout_seconds) - time.time())
@@ -454,6 +461,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
                 decrypted_files = remote_files.copy()
 
+                self.logger.info(f"Decrypted {len(remote_files)} files")
+
             i = 0
             for dest_file_spec in self.dest_file_specs:
                 encryption_requested = (
@@ -502,6 +511,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     )
 
                     encrypted_files = remote_files.copy()
+
+                    self.logger.info(f"Encrypted {len(remote_files)} files")
 
                 # Handle the push transfers first
                 associated_dest_remote_handler = self.dest_remote_handlers[i]
@@ -611,6 +622,8 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         )
 
                 i += 1
+
+                self.logger.info(f"Transferred {len(remote_files)} files")
 
             if (
                 different_protocols


### PR DESCRIPTION
This pull request adds detailed logging to the file transfer and post-processing workflows for both local and SFTP handlers, as well as the main transfer task. The new log messages provide better visibility into file operations such as copying, deleting, renaming, flag file creation, and encryption/decryption steps. This will make it easier to debug issues and trace the flow of files through the system.

**Enhanced Logging for File Operations**

* Added info-level log messages after key file operations (copy, delete, rename, flag file creation) in the local file handler (`src/opentaskpy/remotehandlers/local.py`). [[1]](diffhunk://#diff-b591fc4a14bf567e8a0c0eda5e1180ece4ea3286aa30bea50b2c0bb91e080685R196-R199) [[2]](diffhunk://#diff-b591fc4a14bf567e8a0c0eda5e1180ece4ea3286aa30bea50b2c0bb91e080685R234) [[3]](diffhunk://#diff-b591fc4a14bf567e8a0c0eda5e1180ece4ea3286aa30bea50b2c0bb91e080685R280-R282) [[4]](diffhunk://#diff-b591fc4a14bf567e8a0c0eda5e1180ece4ea3286aa30bea50b2c0bb91e080685R303-R305) [[5]](diffhunk://#diff-b591fc4a14bf567e8a0c0eda5e1180ece4ea3286aa30bea50b2c0bb91e080685R334-R335)
* Added similar info-level log messages for SFTP file operations, including after file transfers, deletions, renames, and flag file creation (`src/opentaskpy/remotehandlers/sftp.py`). [[1]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R305-R307) [[2]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194L387-R392) [[3]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R447-R450) [[4]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R494) [[5]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R558-R561) [[6]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R589-R591) [[7]](diffhunk://#diff-d76c222736d9afa34185af388de56f51f0debad8c914e9e25bdff7614a6f7194R620)

**Improved Logging in Transfer Task**

* Added log messages to `src/opentaskpy/taskhandlers/transfer.py` to report on search patterns, found files, and the results of encryption, decryption, and transfer steps. [[1]](diffhunk://#diff-dacf7e85c8426177033abd433a68766825ee547a90f72b387d64ff4ce893b75dR278-R292) [[2]](diffhunk://#diff-dacf7e85c8426177033abd433a68766825ee547a90f72b387d64ff4ce893b75dR464-R465) [[3]](diffhunk://#diff-dacf7e85c8426177033abd433a68766825ee547a90f72b387d64ff4ce893b75dR515-R516) [[4]](diffhunk://#diff-dacf7e85c8426177033abd433a68766825ee547a90f72b387d64ff4ce893b75dR626-R627)