### PR TITLE
Fix race condition in logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# v25.8.0
+# v25.8.1
 
 - Handle race condition when creating directories in logging module, triggered byu many threads trying to create the same directory at the same time.
 - Enforce log output bufering to flush after newline characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# v25.8.0
+
+- Handle race condition when creating directories in logging module, triggered byu many threads trying to create the same directory at the same time.
+- Enforce log output bufering to flush after newline characters.
+
 # v25.37.0
 
 - Add additional logging to `sftp` & `local` protocol.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v25.37.0"
+version = "v26.8.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v25.37.0"
+current_version = "v26.8.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ requires-python = ">=3.11"
 dev = [
     "types-requests >=2.28",
     "types-paramiko >=3.0",
-    "black == 25.1.0",
+    "black == 26.1.0",
     "isort",
     "pytest",
     "bumpver",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v26.8.0"
+version = "v26.8.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -71,7 +71,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.8.0"
+current_version = "v26.8.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/cli/task_run.py
+++ b/src/opentaskpy/cli/task_run.py
@@ -18,8 +18,7 @@ def main() -> None:
     """Parse args and call TaskRun class."""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        epilog=dedent(
-            """\
+        epilog=dedent("""\
                                 Environment Variables:
 
                                 There are several environment variables that can be used to impact the behaviour:
@@ -44,8 +43,7 @@ def main() -> None:
 
                                 e.g. OTF_OVERRIDE_TRANSFER_DESTINATION_0_PROTOCOL_CREDENTIALS_USERNAME
 
-                                """
-        ),
+                                """),
     )
 
     parser.add_argument(

--- a/src/opentaskpy/otflogging.py
+++ b/src/opentaskpy/otflogging.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import threading
 from datetime import datetime
 
 OTF_LOG_FORMAT = (
@@ -393,7 +394,11 @@ def close_log_file(logger__: logging.Logger, result: bool = False) -> None:
         # Now everything is closed, we can rename the log file
         # If result is True, then rename the file and remove _running from the name
         if new_log_filename:
-            os.rename(log_file_name, new_log_filename)
+            # Use lock to prevent race condition when multiple threads rename same file
+            with _file_operations_lock:
+                # Check file still exists before renaming (another thread may have renamed it)
+                if os.path.exists(log_file_name):
+                    os.rename(log_file_name, new_log_filename)
 
             # Change the basename of the handler to match the new filename, in case it
             # wants to log anything else
@@ -443,6 +448,9 @@ def redact(log_message: str) -> str:
 
 logger = init_logging(__name__)
 
+# Thread lock for directory creation and file operations
+_file_operations_lock = threading.Lock()
+
 
 # mypy: ignore-errors
 class TaskFileHandler(logging.FileHandler):
@@ -461,3 +469,22 @@ class TaskFileHandler(logging.FileHandler):
         """
         _mkdir(os.path.dirname(filename))
         logging.FileHandler.__init__(self, filename, mode, encoding, delay)
+
+    def _open(self):
+        """Open the log file, ensuring the directory exists.
+
+        Overrides the FileHandler._open to ensure directory creation is thread-safe
+        even when delay=True is used. Also uses line buffering for real-time log updates,
+        which is important when using network filesystems like EFS.
+        """
+        # Ensure directory exists with thread safety before opening file
+        with _file_operations_lock:
+            _mkdir(os.path.dirname(self.baseFilename))
+        # Open with line buffering (buffering=1) for real-time log visibility on network filesystems
+        return open(
+            self.baseFilename,
+            self.mode,
+            buffering=1,
+            encoding=self.encoding,
+            errors=self.errors,
+        )


### PR DESCRIPTION
Address race conditions in the logging module when multiple threads attempt to create directories and rename log files simultaneously. Implement thread locks to ensure safe file operations and enable real-time log updates with line buffering.