### PR TITLE
Fix: #161 transfer destinations can be skipped incorrectly under certain circumstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v26.28.0
+
+- Fix the transfer routing bug where destinations could be skipped when a task had multiple destinations with mixed handler types and the final destination matched the source handler type. Closes [#161](https://github.com/open-task-framework/open-task-framework/issues/161)
+
 # v26.18.1
 
 - Fix memory leak in batches caused by now tidying up the remote handler objects after a task has completed.

--- a/all-addons.code-workspace
+++ b/all-addons.code-workspace
@@ -1,28 +1,25 @@
 {
-	"folders": [
-		{
-			"path": "."
-		},
-		{
-			"path": "../otf-addons-o365"
-		},
-		{
-			"path": "../otf-addons-aws"
-		},
-		{
-			"path": "../otf-addons-vault"
-		},
-		{
-			"path": "../otf-addons-winrm"
-		},
-		{
-			"path": "../otf-addons-gcp"
-		}
-	],
-	"settings": {
-		"files.associations": {
-			"*.json": "jsonc"
-		},
-		"ruff.lint.enable": true
-	}
+  "folders": [
+    {
+      "path": ".",
+    },
+    {
+      "path": "../otf-addons-o365",
+    },
+    {
+      "path": "../otf-addons-aws",
+    },
+    {
+      "path": "../otf-addons-winrm",
+    },
+    {
+      "path": "../otf-addons-gcp",
+    },
+  ],
+  "settings": {
+    "files.associations": {
+      "*.json": "jsonc",
+    },
+    "ruff.lint.enable": true,
+  },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v26.18.1"
+version = "v26.28.0"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -72,7 +72,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.18.1"
+current_version = "v26.28.0"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -369,11 +369,15 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         original_file_list = remote_files.copy()
         # If there's a destination file spec, then we need to transfer the files
         if self.dest_file_specs:
+            source_supports_direct_transfer = (
+                self.source_remote_handler.supports_direct_transfer()
+            )
             # Loop through all dest_file specs and see if there are any transfers where the source and dest protocols are different
             # If there are, then we need to do a pull transfer first, then a push transfer
             any_different_protocols = False
-            i = 0
-            for dest_file_spec in self.dest_file_specs:
+            destination_protocol_differences = []
+            requires_local_staging = False
+            for i, dest_file_spec in enumerate(self.dest_file_specs):
                 different_protocols = False
                 if (
                     (
@@ -388,6 +392,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 ):
                     different_protocols = True
                     any_different_protocols = True
+                destination_protocol_differences.append(different_protocols)
 
                 # If there are differences, download the file locally first
                 # so it's ready to upload to multiple destinations at once
@@ -397,25 +402,27 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         "transferType" in dest_file_spec
                         and dest_file_spec["transferType"] == "proxy"
                     )
-                    or not self.source_remote_handler.supports_direct_transfer()
+                    or not source_supports_direct_transfer
                 ):
-                    # Create local staging dir (if this isn't using the local protocol)
-                    if self.source_file_spec["protocol"]["name"] != "local":
-                        makedirs(self.local_staging_dir, exist_ok=True)
-                    else:
-                        self.local_staging_dir = self.source_file_spec["directory"]
-                    transfer_result = self.source_remote_handler.pull_files_to_worker(
-                        remote_files, self.local_staging_dir
+                    requires_local_staging = True
+
+            if requires_local_staging:
+                # Create local staging dir (if this isn't using the local protocol)
+                if self.source_file_spec["protocol"]["name"] != "local":
+                    makedirs(self.local_staging_dir, exist_ok=True)
+                else:
+                    self.local_staging_dir = self.source_file_spec["directory"]
+                transfer_result = self.source_remote_handler.pull_files_to_worker(
+                    remote_files, self.local_staging_dir
+                )
+                # Since files are being pulled locally, encryption/decryption of the files is possible
+                can_do_encryption = True
+                if transfer_result != 0:
+                    return self.return_result(
+                        1,
+                        "Pull to worker from remote source errored",
+                        exception=exceptions.RemoteTransferError,
                     )
-                    # Since files are being pulled locally, encryption/decryption of the files is possible
-                    can_do_encryption = True
-                    if transfer_result != 0:
-                        return self.return_result(
-                            1,
-                            "Pull to worker from remote source errored",
-                            exception=exceptions.RemoteTransferError,
-                        )
-                i += 1
 
             # Before doing any file movements, check to see if file decryption or encryption is
             # required on the source or destination. For any unsupported transferTypes we need to fail here first
@@ -524,7 +531,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                         # And the destination and source remote handler classes are the same
                     )
                     and not any_different_protocols
-                    and self.source_remote_handler.supports_direct_transfer()
+                    and source_supports_direct_transfer
                 ):
                     transfer_result = self.source_remote_handler.transfer_files(
                         remote_files,
@@ -541,15 +548,18 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                     self.logger.info("Transfer completed successfully")
                 # If this is a default push transfer, and source and dest protocols are different
                 elif (
-                    (
-                        "transferType" in dest_file_spec
-                        and (
-                            dest_file_spec["transferType"] == "push"
-                            or dest_file_spec["transferType"] == "proxy"
-                        )
+                    "transferType" not in dest_file_spec
+                    or (
+                        dest_file_spec["transferType"] == "push"
+                        or dest_file_spec["transferType"] == "proxy"
                     )
-                    or different_protocols
-                    or not self.source_remote_handler.supports_direct_transfer()
+                ) and (
+                    any_different_protocols
+                    or (
+                        "transferType" in dest_file_spec
+                        and dest_file_spec["transferType"] == "proxy"
+                    )
+                    or not source_supports_direct_transfer
                 ):
                     self.logger.debug(
                         "Transfer protocols are different, or proxy transfer is"
@@ -599,6 +609,22 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
 
                     self.logger.info("Transfer completed successfully")
 
+                else:
+                    transfer_type = dest_file_spec.get("transferType", "push")
+                    self.logger.warning(
+                        "No valid transfer method available for destination "
+                        f"{dest_file_spec.get('hostname', '<unknown>')} with "
+                        f"transferType={transfer_type}, "
+                        f"source_handler={self.source_remote_handler.__class__.__name__}, "
+                        f"dest_handler={associated_dest_remote_handler.__class__.__name__}, "
+                        f"source_supports_direct_transfer={source_supports_direct_transfer}"
+                    )
+                    return self.return_result(
+                        1,
+                        "No valid transfer method available for destination",
+                        exception=exceptions.RemoteTransferError,
+                    )
+
                 # Handle any ownership and permissions changes
                 if dest_file_spec["protocol"]["name"] == "ssh":
                     move_result = self.dest_remote_handlers[
@@ -626,7 +652,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 self.logger.info(f"Transferred {len(remote_files)} files")
 
             if (
-                different_protocols
+                requires_local_staging
                 and self.source_file_spec["protocol"]["name"] != "dummy"
                 and self.local_staging_dir != self.source_file_spec["directory"]
             ):

--- a/tests/test_taskhandler_transfer_ssh.py
+++ b/tests/test_taskhandler_transfer_ssh.py
@@ -216,6 +216,47 @@ scp_proxy_task_definition = {
     ],
 }
 
+scp_mixed_proxy_task_definition = {
+    "type": "transfer",
+    "source": {
+        "hostname": "172.16.0.11",
+        "directory": "/tmp/testFiles/src",
+        "fileRegex": ".*taskhandler.proxy.mixed\\.txt",
+        "protocol": {"name": "ssh", "credentials": {"username": "application"}},
+    },
+    "destination": [
+        {
+            "hostname": "172.16.0.22",
+            "directory": "/home/application/testFiles/dest",
+            "rename": {
+                "pattern": "^(.*)\\.txt$",
+                "sub": "\\1-sftp.txt",
+            },
+            "protocol": {"name": "sftp", "credentials": {"username": "application"}},
+        },
+        {
+            "hostname": "172.16.0.12",
+            "transferType": "proxy",
+            "directory": "/tmp/testFiles/dest",
+            "rename": {
+                "pattern": "^(.*)\\.txt$",
+                "sub": "\\1-ssh-1.txt",
+            },
+            "protocol": {"name": "ssh", "credentials": {"username": "application"}},
+        },
+        {
+            "hostname": "172.16.0.12",
+            "transferType": "proxy",
+            "directory": "/tmp/testFiles/dest",
+            "rename": {
+                "pattern": "^(.*)\\.txt$",
+                "sub": "\\1-ssh-2.txt",
+            },
+            "protocol": {"name": "ssh", "credentials": {"username": "application"}},
+        },
+    ],
+}
+
 scp_destination_file_rename = {
     "type": "transfer",
     "source": {
@@ -735,6 +776,46 @@ def test_scp_proxy(root_dir, setup_ssh_keys):
     assert transfer_obj.run()
     # Check the destination file exists
     assert os.path.exists(f"{root_dir}/testFiles/ssh_2/dest/test.taskhandler.proxy.txt")
+
+    # Ensure that local files are tidied up
+    assert not os.path.exists(local_staging_dir)
+
+
+def test_scp_proxy_mixed_destinations(root_dir, setup_ssh_keys, setup_sftp_keys):
+    import random
+
+    random_no = random.randint(1, 1000)
+    expected_content = f"test1234-mixed-proxy-route-{random_no}"
+    source_file = f"{root_dir}/testFiles/ssh_1/src/test.taskhandler.proxy.mixed.txt"
+    destination_files = [
+        f"{root_dir}/testFiles/sftp_2/dest/test.taskhandler.proxy.mixed-sftp.txt",
+        f"{root_dir}/testFiles/ssh_2/dest/test.taskhandler.proxy.mixed-ssh-1.txt",
+        f"{root_dir}/testFiles/ssh_2/dest/test.taskhandler.proxy.mixed-ssh-2.txt",
+    ]
+
+    if os.path.exists(source_file):
+        os.remove(source_file)
+
+    for destination_file in destination_files:
+        if os.path.exists(destination_file):
+            os.remove(destination_file)
+
+    # Create a test file
+    fs.create_files([{source_file: {"content": expected_content}}])
+
+    # Create a transfer object
+    transfer_obj = transfer.Transfer(None, "scp-basic", scp_mixed_proxy_task_definition)
+    local_staging_dir = transfer_obj.local_staging_dir
+
+    # Run the transfer and expect a true status
+    assert transfer_obj.run()
+
+    # The first destination uses a different protocol, while the later ssh
+    # destinations explicitly force proxy mode. All three should receive the file.
+    for destination_file in destination_files:
+        assert os.path.exists(destination_file)
+        with open(destination_file, "r") as file_handle:
+            assert file_handle.read() == expected_content
 
     # Ensure that local files are tidied up
     assert not os.path.exists(local_staging_dir)

--- a/tests/test_transfer_destination_routing.py
+++ b/tests/test_transfer_destination_routing.py
@@ -1,0 +1,200 @@
+# pylint: skip-file
+# ruff: noqa
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from opentaskpy.taskhandlers import transfer
+
+
+class RecordingTransferHandler:
+    # Small in-memory test double that records which transfer path was chosen.
+    def __init__(self, files=None, supports_direct=True):
+        self.files = files or {}
+        self.supports_direct = supports_direct
+        self.list_files_calls = []
+        self.pull_files_to_worker_calls = []
+        self.transfer_files_calls = []
+        self.push_files_from_worker_calls = []
+        self.pull_files_calls = []
+        self.tidy_calls = 0
+
+    def supports_direct_transfer(self):
+        return self.supports_direct
+
+    def list_files(self, directory=None, file_pattern=None):
+        self.list_files_calls.append((directory, file_pattern))
+        return self.files
+
+    def pull_files_to_worker(self, files, local_staging_directory):
+        self.pull_files_to_worker_calls.append((files, local_staging_directory))
+        return 0
+
+    def transfer_files(self, files, remote_spec, dest_remote_handler=None):
+        self.transfer_files_calls.append((files, remote_spec, dest_remote_handler))
+        return 0
+
+    def push_files_from_worker(self, local_staging_directory, file_list=None):
+        self.push_files_from_worker_calls.append((local_staging_directory, file_list))
+        return 0
+
+    def pull_files(self, files, source_file_spec=None):
+        self.pull_files_calls.append((files, source_file_spec))
+        return 0
+
+    def move_files_to_final_location(self, files):
+        return 0
+
+    def handle_post_copy_action(self, files):
+        return 0
+
+    def tidy(self):
+        self.tidy_calls += 1
+
+
+class AlternateRecordingTransferHandler(RecordingTransferHandler):
+    # Separate subclass so the transfer handler sees a different remote handler type.
+    pass
+
+
+def build_transfer_with_handlers(
+    tmp_path,
+    dest_handlers,
+    source_protocol_name="local",
+    dest_file_specs=None,
+):
+    # Build the minimum Transfer object needed to exercise the routing logic in
+    # Transfer.run() without depending on real SSH/SFTP/local filesystem transfers.
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    source_file = source_dir / "example.txt"
+    source_handler = RecordingTransferHandler(files={str(source_file): {}})
+
+    transfer_obj = transfer.Transfer(None, "routing-regression", {})
+    transfer_obj.source_file_spec = {
+        "directory": str(source_dir),
+        "fileRegex": ".*\\.txt",
+        "protocol": {"name": source_protocol_name},
+    }
+    if dest_file_specs is None:
+        dest_file_specs = [
+            {
+                "directory": str(tmp_path / f"dest-{index}"),
+                "protocol": {"name": "local"},
+            }
+            for index, _ in enumerate(dest_handlers)
+        ]
+    transfer_obj.dest_file_specs = dest_file_specs
+    transfer_obj.source_remote_handler = source_handler
+    transfer_obj.dest_remote_handlers = dest_handlers
+    transfer_obj.local_staging_dir = str(source_dir)
+    transfer_obj._set_remote_handlers = lambda: None
+
+    return transfer_obj, source_handler
+
+
+def test_mixed_destinations_push_from_worker_when_last_destination_differs(tmp_path):
+    # Control case: when the final destination is the different handler type, the
+    # current implementation correctly stages once and pushes to both destinations.
+    same_type_dest = RecordingTransferHandler()
+    different_type_dest = AlternateRecordingTransferHandler()
+
+    transfer_obj, source_handler = build_transfer_with_handlers(
+        tmp_path, [same_type_dest, different_type_dest]
+    )
+
+    assert transfer_obj.run()
+
+    assert len(source_handler.pull_files_to_worker_calls) == 1
+    assert len(source_handler.transfer_files_calls) == 0
+    assert len(same_type_dest.push_files_from_worker_calls) == 1
+    assert len(different_type_dest.push_files_from_worker_calls) == 1
+
+
+def test_mixed_destinations_push_from_worker_when_last_destination_matches_source(
+    tmp_path,
+):
+    # Regression case from issue #161: reordering the same destinations should not
+    # change behavior, but today the earlier mismatched destination is skipped.
+    different_type_dest = AlternateRecordingTransferHandler()
+    same_type_dest = RecordingTransferHandler()
+
+    transfer_obj, source_handler = build_transfer_with_handlers(
+        tmp_path, [different_type_dest, same_type_dest]
+    )
+
+    assert transfer_obj.run()
+
+    assert len(source_handler.pull_files_to_worker_calls) == 1
+    assert len(source_handler.transfer_files_calls) == 0
+    assert len(different_type_dest.push_files_from_worker_calls) == 1
+    assert len(same_type_dest.push_files_from_worker_calls) == 1
+
+
+def test_invalid_transfer_type_warns_and_fails_fast(tmp_path):
+    # Defensive case: if a destination somehow reaches runtime with an unsupported
+    # transferType, the handler should warn and fail instead of silently claiming a
+    # transfer completed.
+    same_type_dest = RecordingTransferHandler()
+
+    transfer_obj, _ = build_transfer_with_handlers(tmp_path, [same_type_dest])
+    transfer_obj.dest_file_specs[0]["transferType"] = "invalid"
+    transfer_obj.logger = MagicMock(wraps=transfer_obj.logger)
+
+    with pytest.raises(Exception) as exc_info:
+        transfer_obj.run()
+
+    assert "No valid transfer method available for destination" in str(exc_info.value)
+    transfer_obj.logger.warning.assert_called_once()
+    assert len(same_type_dest.push_files_from_worker_calls) == 0
+    assert len(same_type_dest.pull_files_calls) == 0
+
+
+def test_proxy_ssh_destinations_override_direct_capability_in_mixed_transfer(
+    tmp_path,
+):
+    # Even when the source handler supports direct transfer, explicit proxy
+    # destinations must still route via local staging. Including a different
+    # handler type here mirrors the mixed-destination scenario from issue #161.
+    first_proxy_ssh_dest = RecordingTransferHandler()
+    different_protocol_dest = AlternateRecordingTransferHandler()
+    second_proxy_ssh_dest = RecordingTransferHandler()
+
+    transfer_obj, source_handler = build_transfer_with_handlers(
+        tmp_path,
+        [
+            first_proxy_ssh_dest,
+            different_protocol_dest,
+            second_proxy_ssh_dest,
+        ],
+        source_protocol_name="ssh",
+        dest_file_specs=[
+            {
+                "hostname": "172.16.0.12",
+                "directory": str(tmp_path / "ssh-dest-1"),
+                "transferType": "proxy",
+                "protocol": {"name": "ssh"},
+            },
+            {
+                "hostname": "172.16.0.13",
+                "directory": str(tmp_path / "sftp-dest"),
+                "protocol": {"name": "sftp"},
+            },
+            {
+                "hostname": "172.16.0.14",
+                "directory": str(tmp_path / "ssh-dest-2"),
+                "transferType": "proxy",
+                "protocol": {"name": "ssh"},
+            },
+        ],
+    )
+
+    assert transfer_obj.run()
+
+    assert len(source_handler.pull_files_to_worker_calls) == 1
+    assert len(source_handler.transfer_files_calls) == 0
+    assert len(first_proxy_ssh_dest.push_files_from_worker_calls) == 1
+    assert len(different_protocol_dest.push_files_from_worker_calls) == 1
+    assert len(second_proxy_ssh_dest.push_files_from_worker_calls) == 1


### PR DESCRIPTION
## Summary

Fix the transfer routing bug where destinations could be skipped when a task had multiple destinations with mixed handler types and the final destination matched the source handler type.

The fix makes routing decisions per destination instead of reusing stale state from a previous loop iteration. It also keeps staged/proxy transfers working correctly when any destination requires local staging, and adds a defensive failure path if no valid transfer method can be selected for a destination.

Closes #161.

## What changed

- track protocol-difference state per destination in the transfer handler
- stage to the worker once when any destination requires proxy/local staging
- route default `push` destinations through worker staging when the overall transfer requires it
- add a warning and fail fast if no transfer path matches a destination
- add focused routing tests for the mixed-destination bug
- add a real SSH/SFTP integration test covering mixed destinations with `transferType: proxy`

## Why

Previously, the transfer loop reused the value of `different_protocols` from the final destination in the pre-pass. In mixed-destination transfers, that could cause earlier destinations to miss the correct staged push path and be skipped.

This especially matters for cases where direct transfer is supported in principle, but individual destinations explicitly force proxy mode.

## Validation

- `python3 -m pytest tests/test_transfer_destination_routing.py -q`
- `python3 -m pytest tests/test_taskhandler_transfer_ssh.py::test_scp_proxy_mixed_destinations -q`
- `python3 -m pytest tests/test_taskhandler_transfer_ssh.py::test_scp_proxy tests/test_taskhandler_transfer_sftp.py::test_sftp_proxy -q`
- `python3 -m pytest tests/test_taskhandler_transfer_ssh.py::test_scp_proxy tests/test_task_run.py::test_scp_basic_multiple_dests -q`