### PR TITLE
Fix batch timeout handling for tasks that complete after timeout is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v26.28.1
+
+- Fix batch timeout handling so tasks are not marked failed immediately when a timeout is reached, allowing tasks that continue running and complete successfully to be recorded as successful. This is significant for S3 transfers for example where the transfer cannot be killed, and may complete successfully if there is an in-flight transfer actively downloading/uploading. Closes [#162](https://github.com/open-task-framework/open-task-framework/issues/162)
+
 # v26.28.0
 
 - Fix the transfer routing bug where destinations could be skipped when a task had multiple destinations with mixed handler types and the final destination matched the source handler type. Closes [#161](https://github.com/open-task-framework/open-task-framework/issues/161)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,11 @@
 
 [mypy]
+mypy_path = src
+explicit_package_bases = true
 python_version = 3.11
 plugins = pydantic.mypy
 show_error_codes = true
-follow_imports = skip
+follow_imports = normal
 ignore_missing_imports = true
 local_partial_types = true
 strict_equality = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentaskpy"
-version = "v26.28.0"
+version = "v26.28.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license-files = [ "LICENSE" ]
 
@@ -72,7 +72,7 @@ otf-batch-validator = "opentaskpy.cli.batch_validator:main"
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v26.28.0"
+current_version = "v26.28.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/src/opentaskpy/config/loader.py
+++ b/src/opentaskpy/config/loader.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import os
 import sys
+from collections.abc import MutableMapping
 from glob import glob
 from typing import Any
 
@@ -109,7 +110,7 @@ class ConfigLoader:
                     self.file_cache[file_path] = file.read()
         self.logger.log(12, f"Preloaded {len(self.file_cache)} files into memory.")
 
-    def _load_filters(self, destination: dict) -> None:
+    def _load_filters(self, destination: MutableMapping[str, Any]) -> None:
         """Load default filters from opentaskpy.filters.default_filters.
 
         Args:

--- a/src/opentaskpy/config/schemas.py
+++ b/src/opentaskpy/config/schemas.py
@@ -6,6 +6,7 @@ import json
 import sys
 from importlib.resources import files
 from pathlib import Path
+from typing import cast
 
 from jsonschema import Draft202012Validator, validate, validators
 from jsonschema.exceptions import ValidationError
@@ -140,7 +141,7 @@ def validate_transfer_json(json_data: dict) -> bool:
     try:
 
         # Load the schema file for XXX_source
-        resolver = Registry(retrieve=_retrieve_from_filesystem)
+        resolver = Registry(retrieve=_retrieve_from_filesystem)  # type: ignore[call-arg]
 
         validator = DefaultValidatingValidator(
             TRANSFER_SCHEMA,
@@ -178,7 +179,7 @@ def validate_transfer_json(json_data: dict) -> bool:
             source_protocol = source_protocol.split(".")[-2]
 
             # Append new path to the resolver
-            resolver.with_resource(module_path.as_uri(), module_path)  # type: ignore[attr-defined]
+            resolver.with_resource(cast(Path, module_path).as_uri(), module_path)  # type: ignore[arg-type]
         else:
             # Default protocol
             module_path = schema_dir
@@ -209,7 +210,7 @@ def validate_transfer_json(json_data: dict) -> bool:
                     destination_protocol = destination_protocol.split(".")[-2]
 
                     # Append new path to the resolver
-                    resolver.with_resource(module_path.as_uri(), module_path)  # type: ignore[attr-defined]
+                    resolver.with_resource(cast(Path, module_path).as_uri(), module_path)  # type: ignore[arg-type]
                 else:
                     # Default protocol
                     module_path = schema_dir
@@ -277,7 +278,7 @@ def validate_execution_json(json_data: dict) -> bool:
         schema_dir = files("opentaskpy.config").joinpath("schemas")
 
         # Load the schema file for xxx
-        resolver = Registry(retrieve=_retrieve_from_filesystem)
+        resolver = Registry(retrieve=_retrieve_from_filesystem)  # type: ignore[call-arg]
 
         if "." in protocol:
             # Get the full package name from the class name (strip the class off the end)
@@ -291,7 +292,7 @@ def validate_execution_json(json_data: dict) -> bool:
             protocol = protocol.split(".")[-2]
 
             # Append new path to the resolver
-            resolver.with_resource(module_path.as_uri(), module_path)  # type: ignore[attr-defined]
+            resolver.with_resource(cast(Path, module_path).as_uri(), module_path)  # type: ignore[arg-type]
         else:
             # Default protocol
             module_path = schema_dir
@@ -331,7 +332,7 @@ def validate_batch_json(json_data: dict) -> bool:
     """
     try:
         # Load the schema file for xxx
-        resolver = Registry(retrieve=_retrieve_from_filesystem)
+        resolver = Registry(retrieve=_retrieve_from_filesystem)  # type: ignore[call-arg]
 
         validator = DefaultValidatingValidator(
             BATCH_SCHEMA,

--- a/src/opentaskpy/exceptions.py
+++ b/src/opentaskpy/exceptions.py
@@ -1,12 +1,10 @@
 """A bunch of exceptions that can be raised by the opentaskpy package."""
 
-# mypy: ignore-errors
-
 
 class FileTooNewError(Exception):
     """File too new error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -14,7 +12,7 @@ class FileTooNewError(Exception):
 class LogWatchTimeoutError(Exception):
     """Log watch timeout error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -22,7 +20,7 @@ class LogWatchTimeoutError(Exception):
 class LogWatchInitError(Exception):
     """Log watch init error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -30,7 +28,7 @@ class LogWatchInitError(Exception):
 class RemoteTransferError(Exception):
     """Remote transfer error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -38,7 +36,7 @@ class RemoteTransferError(Exception):
 class RemoteFileNotFoundError(Exception):
     """Remote file not found error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -46,7 +44,7 @@ class RemoteFileNotFoundError(Exception):
 class FilesDoNotMeetConditionsError(Exception):
     """Files do not meet conditions error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -54,7 +52,7 @@ class FilesDoNotMeetConditionsError(Exception):
 class DuplicateConfigFileError(Exception):
     """Duplicate config file error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -62,7 +60,7 @@ class DuplicateConfigFileError(Exception):
 class InvalidConfigError(Exception):
     """Invalid config error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -70,7 +68,7 @@ class InvalidConfigError(Exception):
 class UnknownProtocolError(Exception):
     """Unknown protocol error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -78,7 +76,7 @@ class UnknownProtocolError(Exception):
 class LookupPluginError(Exception):
     """Lookup plugin error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -86,7 +84,7 @@ class LookupPluginError(Exception):
 class CachingPluginError(Exception):
     """Caching plugin error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -94,7 +92,7 @@ class CachingPluginError(Exception):
 class VariableResolutionTooDeepError(Exception):
     """Variable resolution too deep error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -102,7 +100,7 @@ class VariableResolutionTooDeepError(Exception):
 class SSHClientError(Exception):
     """SSH client error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -110,7 +108,7 @@ class SSHClientError(Exception):
 class DecryptionNotSupportedError(Exception):
     """Decryption not supported error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -118,7 +116,7 @@ class DecryptionNotSupportedError(Exception):
 class EncryptionNotSupportedError(Exception):
     """Encryption not supported error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -126,7 +124,7 @@ class EncryptionNotSupportedError(Exception):
 class EncryptionError(Exception):
     """Generic encryption error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)
 
@@ -134,6 +132,6 @@ class EncryptionError(Exception):
 class DecryptionError(Exception):
     """Generic decryption error."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Call the base class constructor."""
         super().__init__(message)

--- a/src/opentaskpy/remotehandlers/dummy.py
+++ b/src/opentaskpy/remotehandlers/dummy.py
@@ -4,6 +4,7 @@ This module doesn't actually do anything, it's just used for testing the cacheab
 variables.
 """
 
+from collections.abc import Collection
 from random import randint
 
 from opentaskpy.config.variablecaching import cache_utils
@@ -65,7 +66,7 @@ class DummyTransfer(RemoteTransferHandler):
         return {}
 
     def pull_files_to_worker(
-        self, files: list[str], local_staging_directory: str  # noqa: ARG002
+        self, files: Collection[str], local_staging_directory: str  # noqa: ARG002
     ) -> int:
         """Pull files to the worker.
 
@@ -91,19 +92,26 @@ class DummyTransfer(RemoteTransferHandler):
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def transfer_files(self, files: list[str]) -> None:
+    def transfer_files(
+        self,
+        files: Collection[str],
+        remote_spec: dict,
+        dest_remote_handler: RemoteTransferHandler | None = None,
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def pull_files(self, files: list[str]) -> None:
+    def pull_files(
+        self, files: Collection[str], remote_spec: dict | None = None
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def move_files_to_final_location(self, files: list[str]) -> None:
+    def move_files_to_final_location(self, files: Collection[str]) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def handle_post_copy_action(self, files: list[str]) -> int:  # noqa: ARG002
+    def handle_post_copy_action(self, files: Collection[str]) -> int:  # noqa: ARG002
         """Handle the post copy action specified in the config.
 
         Args:

--- a/src/opentaskpy/remotehandlers/email.py
+++ b/src/opentaskpy/remotehandlers/email.py
@@ -4,6 +4,7 @@ import glob
 import os
 import re
 import smtplib
+from collections.abc import Collection
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -231,11 +232,13 @@ class EmailTransfer(RemoteTransferHandler):
 
         return result
 
-    def pull_files_to_worker(self, local_staging_directory: str) -> int:
+    def pull_files_to_worker(
+        self, files: Collection[str], local_staging_directory: str
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def handle_post_copy_action(self, files: list) -> None:
+    def handle_post_copy_action(self, files: Collection[str]) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
@@ -245,16 +248,21 @@ class EmailTransfer(RemoteTransferHandler):
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def move_files_to_final_location(self, files: list) -> None:
+    def move_files_to_final_location(self, files: Collection[str]) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def pull_files(self, files: list) -> None:
+    def pull_files(
+        self, files: Collection[str], remote_spec: dict | None = None
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
     def transfer_files(
-        self, files: dict, remote_spec: dict, dest_remote_handler: dict | None = None
-    ) -> None:
+        self,
+        files: Collection[str],
+        remote_spec: dict,
+        dest_remote_handler: RemoteTransferHandler | None = None,
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError

--- a/src/opentaskpy/remotehandlers/local.py
+++ b/src/opentaskpy/remotehandlers/local.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import stat
 import subprocess
+from collections.abc import Collection
 from shlex import quote
 
 import opentaskpy.otflogging
@@ -101,7 +102,7 @@ class LocalTransfer(RemoteTransferHandler):
         return result
 
     def pull_files_to_worker(
-        self, files: list[str], local_staging_directory: str  # noqa: ARG002
+        self, files: Collection[str], local_staging_directory: str  # noqa: ARG002
     ) -> int:
         """Pull files to the worker.
 
@@ -203,19 +204,26 @@ class LocalTransfer(RemoteTransferHandler):
 
         return result
 
-    def transfer_files(self, files: list[str]) -> None:
+    def transfer_files(
+        self,
+        files: Collection[str],
+        remote_spec: dict,
+        dest_remote_handler: RemoteTransferHandler | None = None,
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def pull_files(self, files: list[str]) -> None:
+    def pull_files(
+        self, files: Collection[str], remote_spec: dict | None = None
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def move_files_to_final_location(self, files: list[str]) -> None:
+    def move_files_to_final_location(self, files: Collection[str]) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def handle_post_copy_action(self, files: list[str]) -> int:
+    def handle_post_copy_action(self, files: Collection[str]) -> int:
         """Handle the post copy action specified in the config.
 
         Args:

--- a/src/opentaskpy/remotehandlers/remotehandler.py
+++ b/src/opentaskpy/remotehandlers/remotehandler.py
@@ -1,6 +1,9 @@
 """Abstract classes for remote handlers."""
 
 from abc import ABC, abstractmethod
+from typing import Any
+
+TransferFileSet = list[str] | dict[str, Any]
 
 
 class RemoteHandler(ABC):
@@ -13,6 +16,15 @@ class RemoteHandler(ABC):
             spec (dict): The spec for the handler.
         """
         self.spec = spec
+
+    def tidy(self) -> None:
+        """Tidy up any underlying connection state."""
+
+    def kill(self) -> None:
+        """Attempt to stop any remote work in progress."""
+
+    def set_handler_vars(self, protocol_vars: dict) -> None:
+        """Set any protocol-specific variables for the handler."""
 
 
 class RemoteTransferHandler(RemoteHandler):
@@ -42,9 +54,9 @@ class RemoteTransferHandler(RemoteHandler):
     @abstractmethod
     def transfer_files(
         self,
-        files: list[str],
+        files: TransferFileSet,
         remote_spec: dict,
-        dest_remote_handler: dict | None = None,
+        dest_remote_handler: "RemoteTransferHandler" | None = None,
     ) -> int:
         """Transfer files to the remote location.
 
@@ -76,7 +88,7 @@ class RemoteTransferHandler(RemoteHandler):
 
     @abstractmethod
     def pull_files_to_worker(
-        self, files: list[str], local_staging_directory: str
+        self, files: TransferFileSet, local_staging_directory: str
     ) -> int:
         """Pull files from the remote location to the worker.
 
@@ -89,20 +101,23 @@ class RemoteTransferHandler(RemoteHandler):
         """
 
     @abstractmethod
-    def pull_files(self, files: list[str]) -> int:
+    def pull_files(
+        self, files: TransferFileSet, remote_spec: dict | None = None
+    ) -> int:
         """Pull files from the remote location to the destination system.
 
         Used when a direct push cannot be done, and the files need to be pulled instead.
 
         Args:
             files (list[str]): The files to pull.
+            remote_spec (dict, optional): The remote spec for the transfer. Defaults to None.
 
         Returns:
             int: The result of the transfer. 0 for success, 1 for failure.
         """
 
     @abstractmethod
-    def move_files_to_final_location(self, files: dict) -> int:
+    def move_files_to_final_location(self, files: TransferFileSet) -> int:
         """Move files to their final location.
 
         Once dropped on the destination system, the files may need to be moved to their
@@ -116,7 +131,7 @@ class RemoteTransferHandler(RemoteHandler):
         """
 
     @abstractmethod
-    def handle_post_copy_action(self, files: list[str]) -> int:
+    def handle_post_copy_action(self, files: TransferFileSet) -> int:
         """Handle any post copy actions.
 
         Post Copy Actions (PCA) are actions that need to be performed after the files
@@ -139,8 +154,17 @@ class RemoteTransferHandler(RemoteHandler):
         appropriate caching plugin.
         """
 
-    def tidy(self) -> None:
-        """Tidy up after the transfer, if necessary. Otherwise do nothing."""
+    def init_logwatch(self) -> int:
+        """Initialise log watch support if the handler implements it."""
+        raise NotImplementedError
+
+    def do_logwatch(self) -> int:
+        """Perform one log watch poll if the handler implements it."""
+        raise NotImplementedError
+
+    def create_flag_files(self) -> int:
+        """Create any remote flag files required by the handler."""
+        raise NotImplementedError
 
     def obtain_variable_from_spec(self, variable_name: str, spec: dict) -> str:
         """Using the spec, obtain the current value of the variable.

--- a/src/opentaskpy/remotehandlers/remotehandler.py
+++ b/src/opentaskpy/remotehandlers/remotehandler.py
@@ -1,5 +1,7 @@
 """Abstract classes for remote handlers."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -56,7 +58,7 @@ class RemoteTransferHandler(RemoteHandler):
         self,
         files: TransferFileSet,
         remote_spec: dict,
-        dest_remote_handler: "RemoteTransferHandler" | None = None,
+        dest_remote_handler: RemoteTransferHandler | None = None,
     ) -> int:
         """Transfer files to the remote location.
 

--- a/src/opentaskpy/remotehandlers/sftp.py
+++ b/src/opentaskpy/remotehandlers/sftp.py
@@ -8,6 +8,7 @@ import os
 import re
 import stat
 import time
+from collections.abc import Collection
 from io import StringIO
 from shlex import quote
 
@@ -131,7 +132,7 @@ class SFTPTransfer(RemoteTransferHandler):
             retry_if_not_exception_message(
                 match=r".*(not found in known_hosts|Name or service not known|Not retrying due to config).*"
             )
-            & retry_if_exception(Exception)
+            & retry_if_exception(lambda ex: isinstance(ex, Exception))
         ),
     )
     def connect_with_retry(self, client_kwargs: dict) -> None:
@@ -265,7 +266,7 @@ class SFTPTransfer(RemoteTransferHandler):
         return remote_files
 
     def pull_files_to_worker(
-        self, files: list[str], local_staging_directory: str
+        self, files: Collection[str], local_staging_directory: str
     ) -> int:
         """Pull files to the worker.
 
@@ -456,19 +457,26 @@ class SFTPTransfer(RemoteTransferHandler):
 
         return result
 
-    def transfer_files(self, files: list[str]) -> None:
+    def transfer_files(
+        self,
+        files: Collection[str],
+        remote_spec: dict,
+        dest_remote_handler: RemoteTransferHandler | None = None,
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def pull_files(self, files: list[str]) -> None:
+    def pull_files(
+        self, files: Collection[str], remote_spec: dict | None = None
+    ) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def move_files_to_final_location(self, files: list[str]) -> None:
+    def move_files_to_final_location(self, files: Collection[str]) -> int:
         """Not implemented for this handler."""
         raise NotImplementedError
 
-    def handle_post_copy_action(self, files: list[str]) -> int:
+    def handle_post_copy_action(self, files: Collection[str]) -> int:
         """Handle the post copy action specified in the config.
 
         Args:

--- a/src/opentaskpy/remotehandlers/ssh.py
+++ b/src/opentaskpy/remotehandlers/ssh.py
@@ -10,6 +10,7 @@ import random
 import re
 import stat
 import time
+from collections.abc import Collection
 from io import StringIO
 from shlex import quote
 
@@ -148,7 +149,7 @@ class SSHTransfer(RemoteTransferHandler):
             retry_if_not_exception_message(
                 match=r".*(not found in known_hosts|Name or service not known).*"
             )
-            & retry_if_exception(Exception)
+            & retry_if_exception(lambda ex: isinstance(ex, Exception))
         ),
     )
     def connect_with_retry(self, ssh_client: SSHClient, kwargs: dict) -> None:
@@ -269,7 +270,7 @@ class SSHTransfer(RemoteTransferHandler):
         return remote_files
 
     def pull_files_to_worker(
-        self, files: list[str], local_staging_directory: str
+        self, files: Collection[str], local_staging_directory: str
     ) -> int:
         """Pull files to the worker.
 
@@ -370,7 +371,7 @@ class SSHTransfer(RemoteTransferHandler):
 
     def transfer_files(
         self,
-        files: list[str],
+        files: Collection[str],
         remote_spec: dict,
         dest_remote_handler: RemoteTransferHandler | None = None,
     ) -> int:
@@ -391,7 +392,7 @@ class SSHTransfer(RemoteTransferHandler):
 
         # If we are given a destination handler, make sure we connect to the host
         if dest_remote_handler:
-            self.connect(remote_host, dest_remote_handler.ssh_client)
+            self.connect(remote_host, dest_remote_handler.ssh_client)  # type: ignore[attr-defined]
 
         # Construct an SCP command to transfer the files to the destination server
         remote_user = (
@@ -405,7 +406,7 @@ class SSHTransfer(RemoteTransferHandler):
 
         # Check that the SFTP client is connected and active
         if dest_remote_handler:
-            dest_sftp_client = dest_remote_handler.ssh_client.open_sftp()
+            dest_sftp_client = dest_remote_handler.ssh_client.open_sftp()  # type: ignore[attr-defined]
 
         # Create/validate staging directory exists on destination
         # Use SFTP connection to check if the directory exists
@@ -443,7 +444,9 @@ class SSHTransfer(RemoteTransferHandler):
 
         return remote_rc
 
-    def pull_files(self, files: list[str], remote_spec: dict) -> int:
+    def pull_files(
+        self, files: Collection[str], remote_spec: dict | None = None
+    ) -> int:
         """Pull files from the source server to the destination server.
 
         Args:
@@ -456,7 +459,7 @@ class SSHTransfer(RemoteTransferHandler):
         self.connect(self.spec["hostname"])
         # Construct an SCP command to transfer the files from the source server
         source_user = self.spec["protocol"]["credentials"]["transferUsername"]
-        source_host = remote_spec["hostname"]
+        source_host = remote_spec["hostname"] if remote_spec else self.spec["hostname"]
 
         # Handle staging directory if there is one
         destination_directory = self.get_staging_directory(self.spec)
@@ -504,7 +507,7 @@ class SSHTransfer(RemoteTransferHandler):
 
         return remote_rc
 
-    def move_files_to_final_location(self, files: dict) -> int:
+    def move_files_to_final_location(self, files: Collection[str]) -> int:
         """Move files from the staging directory to their final location.
 
         Args:
@@ -634,7 +637,7 @@ class SSHTransfer(RemoteTransferHandler):
 
         self.logger.info("### END OF REMOTE OUTPUT ###")
 
-    def handle_post_copy_action(self, files: list[str]) -> int:
+    def handle_post_copy_action(self, files: Collection[str]) -> int:
         """Handle the post copy action specified in the config.
 
         Args:

--- a/src/opentaskpy/taskhandlers/batch.py
+++ b/src/opentaskpy/taskhandlers/batch.py
@@ -5,6 +5,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
 from os import environ
+from typing import Any
 
 import opentaskpy.otflogging
 from opentaskpy.config.loader import ConfigLoader
@@ -39,7 +40,7 @@ class Batch(TaskHandler):
 
     def __init__(
         self,
-        global_config: dict,
+        global_config: dict[str, Any] | None,
         task_id: str,
         batch_definition: dict,
         config_loader: ConfigLoader,
@@ -150,7 +151,7 @@ class Batch(TaskHandler):
                     status = "COMPLETED"
 
             # Create the task handlers for anything we intend on running
-            task_handler = None
+            task_handler: TaskHandler | None = None
             if status == "NOT_STARTED":
                 # Create the appropriate task handler based on the task type
                 if task_definition["type"] == "execution":
@@ -188,24 +189,6 @@ class Batch(TaskHandler):
 
     def _set_remote_handlers(self) -> None:
         pass
-
-    def return_result(
-        self,
-        status: int,
-        message: str | None = None,
-        exception: type[Exception] | None = None,
-    ) -> bool:
-        """Return the result of the task run.
-
-        Args:
-            status (int): The status code to return.
-            message (str, optional): The message to return. Defaults to None.
-            exception (Exception, optional): The exception to return. Defaults to None.
-
-        Returns:
-            bool: The result of the task run.
-        """
-        return super().return_result(status, message, exception)  # type: ignore[no-any-return]
 
     def check_all_dependency_statuses(self, batch_task: dict, statuses: list) -> bool:
         """Check that all batch task dependencies are in a set of states.
@@ -324,29 +307,24 @@ class Batch(TaskHandler):
                     if (
                         time.time() - batch_task["start_time"] > batch_task["timeout"]
                         and batch_task["thread"].is_alive()
+                        and not batch_task.get("timeout_requested", False)
                     ):
                         self.logger.error(
                             f"Task {order_id} ({batch_task['task_id']}) has timed out"
                         )
                         logged = True
-                        batch_task["status"] = "TIMED_OUT"
+                        batch_task["timeout_requested"] = True
                         # Send event to the thread to kill it
                         self.logger.info(
                             f"Sending kill event to task {order_id} ({batch_task['task_id']})"
                         )
                         batch_task["kill_event"].set()
-                        # Wait for the thread to return
-                        batch_task["thread"].join()
-                        self.logger.info(
-                            f"Task {order_id} ({batch_task['task_id']}) has been killed"
-                        )
-                        batch_task["result"] = False
 
                     # Check whether the thread is actually still running.
                     # If it has died uncleanly, then we need to set the appropriate statuses for it
                     if (
                         not batch_task["thread"].is_alive()
-                        and batch_task["status"] != "TIMED_OUT"
+                        and batch_task["status"] == "RUNNING"
                     ):
                         self.logger.error(
                             f"Task {order_id} ({batch_task['task_id']}) has failed"
@@ -481,10 +459,7 @@ class Batch(TaskHandler):
                         12, f"Checking task handler for {batch_task['task_id']}"
                     )
                     # Check to see if the thread is still alive
-                    if (
-                        not batch_task["executing_thread"][0].running()
-                        and batch_task["status"] != "TIMED_OUT"
-                    ):
+                    if batch_task["executing_thread"][0].done():
                         # Get the returncode from the thread
                         self.logger.info(
                             f"{batch_task['task_id']} has finished running"
@@ -493,7 +468,18 @@ class Batch(TaskHandler):
                             0
                         ].result()
 
-                        if batch_task["result"]:
+                        if batch_task.get("timeout_requested", False):
+                            if batch_task["result"]:
+                                self.logger.warning(
+                                    f"{batch_task['task_id']} completed successfully after a timeout was requested"
+                                )
+                                batch_task["status"] = "COMPLETED"
+                            else:
+                                batch_task["status"] = "TIMED_OUT"
+                                self.logger.info(
+                                    f"Task {batch_task['batch_task_spec']['order_id']} ({batch_task['task_id']}) has been killed"
+                                )
+                        elif batch_task["result"]:
                             batch_task["status"] = "COMPLETED"
                         else:
                             batch_task["status"] = "FAILED"
@@ -510,19 +496,15 @@ class Batch(TaskHandler):
 
                     # Check if we have been asked to kill the thread
                     if event.is_set():
-                        self.logger.info(
-                            f"Killing task handler for {batch_task['task_id']}"
-                        )
-                        # Kill the thread and all it's child processes
-                        batch_task["executing_thread"][0].cancel()
-                        executor.shutdown(wait=False)
-                        self._log_task_result(
-                            "FAILED",
-                            batch_task["batch_task_spec"]["order_id"],
-                            batch_task["task_id"],
-                        )
-
-                        break
+                        if not batch_task.get("kill_requested", False):
+                            self.logger.info(
+                                f"Killing task handler for {batch_task['task_id']}"
+                            )
+                            # Try to cancel queued work, but keep waiting for running work
+                            # so we can record its real final state.
+                            batch_task["executing_thread"][0].cancel()
+                            executor.shutdown(wait=False, cancel_futures=True)
+                            batch_task["kill_requested"] = True
 
                     # Wait for the thread to complete
                     self.logger.log(

--- a/src/opentaskpy/taskhandlers/execution.py
+++ b/src/opentaskpy/taskhandlers/execution.py
@@ -2,10 +2,10 @@
 
 import threading
 from concurrent.futures import ThreadPoolExecutor, wait
-from typing import NamedTuple
+from typing import Any, NamedTuple, cast
 
 import opentaskpy.otflogging
-from opentaskpy.remotehandlers.remotehandler import RemoteHandler
+from opentaskpy.remotehandlers.remotehandler import RemoteExecutionHandler
 from opentaskpy.taskhandlers.taskhandler import TaskHandler
 
 
@@ -22,13 +22,18 @@ TASK_TYPE = "E"
 class Execution(TaskHandler):
     """Execution task handler."""
 
-    remote_handlers: list[RemoteHandler] | None = None
+    remote_handlers: list[RemoteExecutionHandler] | None = None
     overall_result: bool = False
 
     _protocol_classes: dict[str, type] = {}  # Class-level cache
     _protocol_lock = threading.Lock()  # Lock for class-level cache
 
-    def __init__(self, global_config: dict, task_id: str, execution_definition: dict):
+    def __init__(
+        self,
+        global_config: dict[str, Any] | None,
+        task_id: str,
+        execution_definition: dict,
+    ):
         """Initialize the execution handler.
 
         Args:
@@ -49,7 +54,7 @@ class Execution(TaskHandler):
         self,
         status: int,
         message: str | None = None,
-        exception: Exception | None = None,
+        exception: type[Exception] | Exception | None = None,
     ) -> bool:
         """Return the result of the task run.
 
@@ -75,7 +80,7 @@ class Execution(TaskHandler):
         # Call super to do the rest
         return super().return_result(status, message, exception)  # type: ignore[no-any-return]
 
-    def _get_remote_host_name(self, remote_handler: RemoteHandler) -> str:
+    def _get_remote_host_name(self, remote_handler: RemoteExecutionHandler) -> str:
         return (
             str(remote_handler.remote_host)
             if hasattr(remote_handler, "remote_host")
@@ -98,20 +103,30 @@ class Execution(TaskHandler):
         if remote_protocol in super().DEFAULT_PROTOCOL_MAP[TASK_TYPE]:
             if "hosts" in self.execution_definition:
                 for host in self.execution_definition["hosts"]:
-                    handler_class = super()._get_default_class(
-                        TASK_TYPE, remote_protocol
+                    handler_class = cast(
+                        Any, super()._get_default_class(TASK_TYPE, remote_protocol)
                     )
-                    remote_handler = handler_class(host, self.execution_definition)
+                    remote_handler = cast(
+                        RemoteExecutionHandler,
+                        handler_class(host, self.execution_definition),
+                    )
 
                     self.remote_handlers.append(remote_handler)
             else:
-                handler_class = super()._get_default_class(TASK_TYPE, remote_protocol)
-                remote_handler = handler_class(self.execution_definition)
+                handler_class = cast(
+                    Any, super()._get_default_class(TASK_TYPE, remote_protocol)
+                )
+                remote_handler = cast(
+                    RemoteExecutionHandler, handler_class(self.execution_definition)
+                )
 
                 self.remote_handlers.append(remote_handler)
         else:
-            remote_handler = super()._get_handler_for_protocol(
-                remote_protocol, self.execution_definition
+            remote_handler = cast(
+                RemoteExecutionHandler,
+                super()._get_handler_for_protocol(
+                    remote_protocol, self.execution_definition
+                ),
             )
             self.remote_handlers.append(remote_handler)
 
@@ -211,7 +226,7 @@ class Execution(TaskHandler):
 
         return self.return_result(1, "Execution(s) failed", ex)
 
-    def _execute(self, remote_handler: RemoteHandler) -> bool:
+    def _execute(self, remote_handler: RemoteExecutionHandler) -> bool:
         result: bool = remote_handler.execute()
         remote_host = self._get_remote_host_name(remote_handler)
         self.logger.info(f"[{remote_host}] Execution returned {result}")

--- a/src/opentaskpy/taskhandlers/taskhandler.py
+++ b/src/opentaskpy/taskhandlers/taskhandler.py
@@ -123,24 +123,26 @@ class TaskHandler(ABC):
             self.logger.log(12, f"Setting handler vars for {source_protocol}")
 
             # Read the protocol specific variables from the global config
-            if (
-                self.global_config
-                and "global_protocol_vars" in self.global_config
-                and next(
-                    (
-                        item
-                        for item in self.global_config["global_protocol_vars"]
-                        if item["name"] == source_protocol
-                    ),
+            if self.global_config and "global_protocol_vars" in self.global_config:
+                raw_protocol_vars = self.global_config["global_protocol_vars"]
+                protocol_var_items = (
+                    raw_protocol_vars
+                    if isinstance(raw_protocol_vars, list)
+                    else [raw_protocol_vars]
                 )
-            ):
                 protocol_vars = next(
                     (
                         item
-                        for item in self.global_config["global_protocol_vars"]
+                        for item in protocol_var_items
                         if item["name"] == source_protocol
                     ),
-                ).copy()
+                    None,
+                )
+            else:
+                protocol_vars = None
+
+            if protocol_vars:
+                protocol_vars = protocol_vars.copy()
                 # Remove "name" from the dict
                 del protocol_vars["name"]
 

--- a/src/opentaskpy/taskhandlers/taskhandler.py
+++ b/src/opentaskpy/taskhandlers/taskhandler.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 from logging import Logger
 from sys import modules
-from typing import NamedTuple
+from typing import Any, NamedTuple, cast
 
 import opentaskpy.otflogging
 from opentaskpy.exceptions import UnknownProtocolError
@@ -54,18 +54,24 @@ class TaskHandler(ABC):
 
     logger: Logger
     overall_result: bool
+    task_id: str
     handled_exception: bool = False
 
-    _protocol_classes: dict[str, type] = {}  # Class-level cache
-    _addon_packages: dict[str, type] = {}  # Class-level cache for addon packages
+    _protocol_classes: dict[str, type[RemoteHandler]] = {}  # Class-level cache
+    _addon_packages: dict[str, type[RemoteHandler]] = (
+        {}
+    )  # Class-level cache for addon packages
     _protocol_lock = threading.Lock()  # Lock for class-level cache
 
-    def __init__(self, global_config: dict):
+    def __init__(self, global_config: dict[str, Any] | None):
         """Initialize the class."""
         self.global_config = global_config
 
     def return_result(
-        self, status: int, message: str, exception: type[Exception] | None = None
+        self,
+        status: int,
+        message: str | None = None,
+        exception: type[Exception] | Exception | None = None,
     ) -> bool:
         """Return the result of the task run.
 
@@ -91,10 +97,10 @@ class TaskHandler(ABC):
         # Throw an exception if we have one
         if exception and not self.handled_exception:
             self.handled_exception = True
-            if callable(exception):
-                raise exception(message)
+            if isinstance(exception, type) and issubclass(exception, Exception):
+                raise exception(message or "")
 
-            raise Exception(message)  # pylint: disable=broad-exception-raised
+            raise Exception(message or "")  # pylint: disable=broad-exception-raised
 
         return status == 0
 
@@ -102,7 +108,7 @@ class TaskHandler(ABC):
     def _set_remote_handlers(self) -> None: ...
 
     @abstractmethod
-    def run(self) -> bool:
+    def run(self, kill_event: threading.Event | None = None) -> bool:
         """Run the task handler.
 
         Returns:
@@ -141,7 +147,7 @@ class TaskHandler(ABC):
                 remote_handler.set_handler_vars(protocol_vars)
 
     def _get_handler_for_protocol(
-        self, protocol_name: str, spec: dict
+        self, protocol_name: str, spec: dict[str, Any]
     ) -> RemoteHandler:
         """Get the handler for a protocol.
 
@@ -181,8 +187,11 @@ class TaskHandler(ABC):
                             )
                             import_module(addon_package)
 
-                        addon_class = getattr(
-                            modules[addon_package], protocol_name.split(".")[-1]
+                        addon_class = cast(
+                            type[RemoteHandler],
+                            getattr(
+                                modules[addon_package], protocol_name.split(".")[-1]
+                            ),
                         )
                         self._addon_packages[protocol_name] = addon_class
                     except ModuleNotFoundError as exc:
@@ -197,7 +206,9 @@ class TaskHandler(ABC):
 
         return addon_class(spec)
 
-    def _get_default_class(self, task_type: str, protocol_name: str) -> type:
+    def _get_default_class(
+        self, task_type: str, protocol_name: str
+    ) -> type[RemoteHandler]:
         try:
             return self._protocol_classes[protocol_name]  # Fast path when cached
         except KeyError:

--- a/src/opentaskpy/taskhandlers/transfer.py
+++ b/src/opentaskpy/taskhandlers/transfer.py
@@ -6,6 +6,7 @@ import threading
 import time
 from math import ceil, floor
 from os import environ, getpid, makedirs, path, remove
+from typing import Any, cast
 
 import gnupg
 
@@ -27,13 +28,18 @@ DEFAULT_STAGING_DIR_BASE = "/tmp"  # nosec B108
 class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
     """Task handler for running transfers."""
 
-    source_remote_handler: RemoteTransferHandler
-    dest_remote_handlers: RemoteTransferHandler = None
+    source_remote_handler: RemoteTransferHandler | None = None
+    dest_remote_handlers: list[RemoteTransferHandler] | None = None
     source_file_spec: dict
     dest_file_specs: list[dict] | None = None
     overall_result: bool = False
 
-    def __init__(self, global_config: dict, task_id: str, transfer_definition: dict):
+    def __init__(
+        self,
+        global_config: dict[str, Any] | None,
+        task_id: str,
+        transfer_definition: dict,
+    ):
         """Create a new transfer task handler.
 
         Args:
@@ -72,7 +78,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         self,
         status: int,
         message: str | None = None,
-        exception: Exception | None = None,
+        exception: type[Exception] | Exception | None = None,
     ) -> bool:
         """Return the result of the task run.
 
@@ -138,13 +144,18 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         # Based on the source protocol pick the appropriate remote handler
         if source_protocol in super().DEFAULT_PROTOCOL_MAP[TASK_TYPE]:
             handler_class = super()._get_default_class(TASK_TYPE, source_protocol)
-            self.source_remote_handler = handler_class(self.source_file_spec)
+            self.source_remote_handler = cast(
+                RemoteTransferHandler, handler_class(self.source_file_spec)
+            )
 
         # If not SSH, then it's a non-standard protocol, we need to see if it's loadable
         # load it, and then create the remote handler
         else:
-            self.source_remote_handler = super()._get_handler_for_protocol(
-                source_protocol, self.source_file_spec
+            self.source_remote_handler = cast(
+                RemoteTransferHandler,
+                super()._get_handler_for_protocol(
+                    source_protocol, self.source_file_spec
+                ),
             )
 
         super()._set_handler_vars(source_protocol, self.source_remote_handler)
@@ -156,16 +167,20 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
                 remote_protocol = dest_file_spec["protocol"]["name"]
 
                 # For each host, create a remote handler
-                remote_handler = None
                 if remote_protocol in super().DEFAULT_PROTOCOL_MAP[TASK_TYPE]:
                     handler_class = super()._get_default_class(
                         TASK_TYPE, remote_protocol
                     )
-                    remote_handler = handler_class(dest_file_spec)
+                    remote_handler = cast(
+                        RemoteTransferHandler, handler_class(dest_file_spec)
+                    )
 
                 else:
-                    remote_handler = super()._get_handler_for_protocol(
-                        remote_protocol, dest_file_spec
+                    remote_handler = cast(
+                        RemoteTransferHandler,
+                        super()._get_handler_for_protocol(
+                            remote_protocol, dest_file_spec
+                        ),
                     )
 
                 self.dest_remote_handlers.append(remote_handler)
@@ -183,6 +198,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         self.logger.info("Running transfer")
 
         self._set_remote_handlers()
+        assert self.source_remote_handler is not None
 
         # If log watching, do that first
         if "logWatch" in self.source_file_spec:
@@ -369,6 +385,7 @@ class Transfer(TaskHandler):  # pylint: disable=too-many-instance-attributes
         original_file_list = remote_files.copy()
         # If there's a destination file spec, then we need to transfer the files
         if self.dest_file_specs:
+            assert self.dest_remote_handlers is not None
             source_supports_direct_transfer = (
                 self.source_remote_handler.supports_direct_transfer()
             )

--- a/tests/test_taskhandler_batch.py
+++ b/tests/test_taskhandler_batch.py
@@ -3,6 +3,7 @@
 import os
 import random
 import shutil
+import time
 
 import pytest
 from pytest_shell import fs
@@ -727,6 +728,52 @@ def test_batch_log_memory_usage(
             os.environ.pop("OTF_LOG_MEMORY_USAGE", None)
         else:
             os.environ["OTF_LOG_MEMORY_USAGE"] = old_value
+        if old_poll is None:
+            os.environ.pop("OTF_BATCH_POLL_INTERVAL", None)
+        else:
+            os.environ["OTF_BATCH_POLL_INTERVAL"] = old_poll
+
+
+def test_batch_timeout_can_complete_if_kill_does_not_interrupt(
+    env_vars, root_dir, clear_logs, no_thread_sleep
+):
+    class SlowSuccessfulTaskHandler:
+        def __init__(self):
+            self.task_id = "slow-success"
+
+        def run(self, kill_event=None):
+            time.sleep(0.2)
+            return True
+
+    old_poll = os.environ.get("OTF_BATCH_POLL_INTERVAL")
+    os.environ["OTF_BATCH_POLL_INTERVAL"] = "0.01"
+    try:
+        config_loader = ConfigLoader("test/cfg")
+        batch_obj = batch.Batch(
+            None,
+            f"timeout-success-{RANDOM}",
+            basic_batch_definition,
+            config_loader,
+        )
+        batch_obj.task_order_tree = {
+            1: {
+                "task_id": "slow-success",
+                "batch_task_spec": {"order_id": 1, "task_id": "slow-success"},
+                "task": {"type": "execution"},
+                "task_handler": SlowSuccessfulTaskHandler(),
+                "timeout": 0.05,
+                "continue_on_fail": False,
+                "retry_on_rerun": False,
+                "status": "NOT_STARTED",
+                "result": None,
+            }
+        }
+
+        assert batch_obj.run()
+        assert batch_obj.task_order_tree[1]["status"] == "COMPLETED"
+        assert batch_obj.task_order_tree[1]["result"] is True
+        assert batch_obj.task_order_tree[1]["kill_event"].is_set()
+    finally:
         if old_poll is None:
             os.environ.pop("OTF_BATCH_POLL_INTERVAL", None)
         else:


### PR DESCRIPTION
## Summary

Fixes batch timeout behaviour where a task could be marked as failed as soon as its timeout was reached, even if the underlying task continued running and later completed successfully. Closes #162 

## What changed

- Changed batch timeout handling so reaching the timeout sends a kill request instead of immediately finalising the task as failed
- Kept the batch worker thread alive until the underlying task future actually exits
- Recorded the real final task status based on the eventual result:
  - `COMPLETED` if the task still finishes successfully
  - `TIMED_OUT` if the task exits unsuccessfully after timeout was requested
- Added regression coverage for tasks that exceed their timeout but still return success

## Why

Some task types can be inside blocking operations that cannot be interrupted immediately. In those cases, the old batch logic would mark the task as failed too early and fail the whole batch, even though the task later completed successfully. This change makes batch status reflect the real final outcome instead of the moment the timeout threshold is crossed.
